### PR TITLE
Update Go version to 1.24.x in CI workflows to match go.mod

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Check gofmt
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Run Unit Tests
         run: |
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Run Redis Tests
         run: |

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
       - name: Run Unit Tests
         run: |


### PR DESCRIPTION
## Description
Bump version of workflows to match go.mod version
 
/cc @zendesk/lockbox

### Purpose

#### What compromises did you make?
N/A

### Risks
N/A
