### PR TITLE
Add WithPrefix OperationOption for cache key prefixing

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,22 +1,22 @@
 package cache
 
 type Cache[K comparable, V any] interface {
-	Get(key K) (v V, wasFound bool, err error)
-	Delete(key K) error
-	Set(key K, value V) error
+	Get(key K, opts ...OperationOption) (v V, wasFound bool, err error)
+	Delete(key K, opts ...OperationOption) error
+	Set(key K, value V, opts ...OperationOption) error
 	Purge() error
 	// Get the value from cache for key K, or setItsValue and return it via func orSet
-	GetOrSet(key K, orSet func() (V, error)) (val V, wasFoundInCache bool, err error)
+	GetOrSet(key K, orSet func() (V, error), opts ...OperationOption) (val V, wasFoundInCache bool, err error)
 }
 
 // CacheBackendAdapter manges reading/writing/deleting to and from a cache backend. E.G. Memory backend, Redis Backend, etc.
 type CacheBackendAdapter[K comparable, V any] interface {
-	Get(key K) (value V, wasFound bool, err error)
-	Set(key K, value V) error
-	Delete(key K) error
+	Get(key K, opts ...OperationOption) (value V, wasFound bool, err error)
+	Set(key K, value V, opts ...OperationOption) error
+	Delete(key K, opts ...OperationOption) error
 	Purge() error // Purges the cache
 	// Get the value from cache for key K, or setItsValue and return it via func orSet
-	GetOrSet(key K, orSet func() (V, error)) (val V, wasFoundInCache bool, err error)
+	GetOrSet(key K, orSet func() (V, error), opts ...OperationOption) (val V, wasFoundInCache bool, err error)
 }
 
 type CacheSetError struct {
@@ -58,9 +58,9 @@ type cache[K comparable, V any] struct {
 	cfg      cacheCfg[K, V]
 }
 
-func (c *cache[K, V]) Get(key K) (V, bool, error) {
+func (c *cache[K, V]) Get(key K, opts ...OperationOption) (V, bool, error) {
 
-	val, fromCache, err := c.backend.Get(key)
+	val, fromCache, err := c.backend.Get(key, opts...)
 	if c.observer != nil {
 		c.observer.Get(key)
 		if fromCache {
@@ -73,20 +73,20 @@ func (c *cache[K, V]) Get(key K) (V, bool, error) {
 	return val, fromCache, err
 }
 
-func (c *cache[K, V]) Set(key K, val V) error {
+func (c *cache[K, V]) Set(key K, val V, opts ...OperationOption) error {
 	if c.observer != nil {
 		c.observer.Set(key)
 	}
 
-	return c.backend.Set(key, val)
+	return c.backend.Set(key, val, opts...)
 }
 
-func (c *cache[K, V]) Delete(key K) error {
+func (c *cache[K, V]) Delete(key K, opts ...OperationOption) error {
 	if c.observer != nil {
 		c.observer.Delete(key)
 	}
 
-	return c.backend.Delete(key)
+	return c.backend.Delete(key, opts...)
 }
 
 func (c *cache[K, V]) Purge() error {
@@ -97,8 +97,8 @@ func (c *cache[K, V]) Purge() error {
 	return c.backend.Purge()
 }
 
-func (c *cache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, wasFoundInCache bool, err error) {
-	v, fromCache, err := c.backend.GetOrSet(key, orSet)
+func (c *cache[K, V]) GetOrSet(key K, orSet func() (V, error), opts ...OperationOption) (val V, wasFoundInCache bool, err error) {
+	v, fromCache, err := c.backend.GetOrSet(key, orSet, opts...)
 
 	if c.observer != nil {
 		c.observer.Get(key)

--- a/cache/encrypted_cache.go
+++ b/cache/encrypted_cache.go
@@ -68,8 +68,8 @@ func NewEncryptedCacheWithPasswordNonce[K comparable, V any](backend CacheBacken
 	return NewEncryptedCacheWithPassword[K, V](backend, password, salt, iterations, opts...)
 }
 
-func (c *EncryptedCache[K, V]) Get(key K) (v V, wasFound bool, err error) {
-	encryptedBytes, _, err := c.backend.Get(key)
+func (c *EncryptedCache[K, V]) Get(key K, opts ...OperationOption) (v V, wasFound bool, err error) {
+	encryptedBytes, _, err := c.backend.Get(key, opts...)
 	if err != nil {
 		return v, false, err
 	}
@@ -87,11 +87,11 @@ func (c *EncryptedCache[K, V]) Get(key K) (v V, wasFound bool, err error) {
 	return v, true, nil
 }
 
-func (c *EncryptedCache[K, V]) Delete(key K) error {
-	return c.backend.Delete(key)
+func (c *EncryptedCache[K, V]) Delete(key K, opts ...OperationOption) error {
+	return c.backend.Delete(key, opts...)
 }
 
-func (c *EncryptedCache[K, V]) Set(key K, value V) error {
+func (c *EncryptedCache[K, V]) Set(key K, value V, opts ...OperationOption) error {
 	// Encrypt the binary value
 	encryptedBytes, err := c.ed.Encrypt(value)
 	if err != nil {
@@ -99,7 +99,7 @@ func (c *EncryptedCache[K, V]) Set(key K, value V) error {
 	}
 
 	// Store the encrypted value in the cache
-	err = c.backend.Set(key, encryptedBytes)
+	err = c.backend.Set(key, encryptedBytes, opts...)
 	if err == nil || c.cfg.ignoreCacheSetErrors {
 		return nil
 	}
@@ -113,8 +113,8 @@ func (c *EncryptedCache[K, V]) Purge() error {
 	return c.backend.Purge()
 }
 
-func (c *EncryptedCache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, wasFoundInCache bool, err error) {
-	item, wasFound, err := c.Get(key)
+func (c *EncryptedCache[K, V]) GetOrSet(key K, orSet func() (V, error), opts ...OperationOption) (val V, wasFoundInCache bool, err error) {
+	item, wasFound, err := c.Get(key, opts...)
 	if wasFound {
 		return item, wasFound, err
 	}
@@ -124,7 +124,7 @@ func (c *EncryptedCache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, 
 		return val, false, err
 	}
 
-	err = c.Set(key, val)
+	err = c.Set(key, val, opts...)
 	if err == nil || c.cfg.ignoreCacheSetErrors {
 		return val, false, nil
 	}

--- a/cache/memory.go
+++ b/cache/memory.go
@@ -6,9 +6,10 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 )
 
-// InMemoryCache adapts ttlCache to integrate it with CacheBackendAdapter
+// InMemoryCache adapts ttlCache to integrate it with CacheBackendAdapter.
+// Keys are hashed to strings internally (via HashAny), matching Redis behavior.
 type InMemoryCache[K comparable, V any] struct {
-	cache       *ttlcache.Cache[K, V]
+	cache       *ttlcache.Cache[string, V]
 	ttl         time.Duration
 	failThrough CacheBackendAdapter[K, V]
 	cfg         cacheBackendCfg[K, V]
@@ -18,16 +19,16 @@ type InMemoryCache[K comparable, V any] struct {
 func NewInMemoryCache[K comparable, V any](ttl time.Duration, opts ...CacheBackendOption[K, V]) CacheBackendAdapter[K, V] {
 	cfg := setBackendOpts(opts...)
 
-	ttlOpts := []ttlcache.Option[K, V]{
-		ttlcache.WithTTL[K, V](ttl),
-		ttlcache.WithDisableTouchOnHit[K, V](),
+	ttlOpts := []ttlcache.Option[string, V]{
+		ttlcache.WithTTL[string, V](ttl),
+		ttlcache.WithDisableTouchOnHit[string, V](),
 	}
 
 	if cfg.capacity > 0 {
-		ttlOpts = append(ttlOpts, ttlcache.WithCapacity[K, V](cfg.capacity))
+		ttlOpts = append(ttlOpts, ttlcache.WithCapacity[string, V](cfg.capacity))
 	}
 
-	ttlCache := ttlcache.New[K, V](ttlOpts...)
+	ttlCache := ttlcache.New[string, V](ttlOpts...)
 
 	cache := InMemoryCache[K, V]{
 		cache:       ttlCache,
@@ -41,20 +42,21 @@ func NewInMemoryCache[K comparable, V any](ttl time.Duration, opts ...CacheBacke
 	return &cache
 }
 
-func (c *InMemoryCache[K, V]) Get(key K) (V, bool, error) {
+func (c *InMemoryCache[K, V]) Get(key K, opts ...OperationOption) (V, bool, error) {
 	var v V
 	if c.cacheIsDisabled() {
 		return v, false, nil
 	}
 
-	item := c.cache.Get(key)
+	k := buildKey(key, opts...)
+	item := c.cache.Get(k)
 	if item != nil {
 		return item.Value(), true, nil
 	}
 
 	// If fail-through is configured, try fail-through
 	if c.failThrough != nil {
-		value, wasFound, err := c.failThrough.Get(key)
+		value, wasFound, err := c.failThrough.Get(key, opts...)
 		if err != nil {
 			return v, wasFound, err
 		}
@@ -62,7 +64,7 @@ func (c *InMemoryCache[K, V]) Get(key K) (V, bool, error) {
 		// Add item to this cache before returning it. Do **NOT** call public set (c.Set) as it will reset the value in the
 		// fail-through cache, so it will never expire (if it's a TTL based cache)
 		if wasFound {
-			_ = c.cache.Set(key, value, c.ttl)
+			_ = c.cache.Set(k, value, c.ttl)
 			return value, true, nil
 		}
 	}
@@ -71,16 +73,17 @@ func (c *InMemoryCache[K, V]) Get(key K) (V, bool, error) {
 	return v, false, nil
 }
 
-func (c *InMemoryCache[K, V]) Set(key K, val V) error {
+func (c *InMemoryCache[K, V]) Set(key K, val V, opts ...OperationOption) error {
 	if c.cacheIsDisabled() {
 		return nil
 	}
 
-	_ = c.cache.Set(key, val, c.ttl)
+	k := buildKey(key, opts...)
+	_ = c.cache.Set(k, val, c.ttl)
 
 	// if fail-through is enabled, set in fail-thorugh
 	if c.failThrough != nil {
-		err := c.failThrough.Set(key, val)
+		err := c.failThrough.Set(key, val, opts...)
 		if err != nil && !c.cfg.ignoreCacheSetErrors {
 			// Error on SET, so we wrap it in RedisCacheSetError
 			err = CacheSetError{Message: err.Error()}
@@ -91,12 +94,13 @@ func (c *InMemoryCache[K, V]) Set(key K, val V) error {
 	return nil
 }
 
-func (c *InMemoryCache[K, V]) Delete(key K) error {
-	c.cache.Delete(key)
+func (c *InMemoryCache[K, V]) Delete(key K, opts ...OperationOption) error {
+	k := buildKey(key, opts...)
+	c.cache.Delete(k)
 
 	// Delete from fail through
 	if c.failThrough != nil {
-		return c.failThrough.Delete(key)
+		return c.failThrough.Delete(key, opts...)
 	}
 
 	return nil
@@ -112,13 +116,13 @@ func (c *InMemoryCache[K, V]) Purge() error {
 	return nil
 }
 
-func (c *InMemoryCache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, wasFoundInCache bool, err error) {
+func (c *InMemoryCache[K, V]) GetOrSet(key K, orSet func() (V, error), opts ...OperationOption) (val V, wasFoundInCache bool, err error) {
 	if c.cacheIsDisabled() {
 		val, err = orSet()
 		return val, false, err
 	}
 
-	item, wasFound, err := c.Get(key)
+	item, wasFound, err := c.Get(key, opts...)
 	if wasFound {
 		return item, wasFound, err
 	}
@@ -128,7 +132,7 @@ func (c *InMemoryCache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, w
 		return val, false, err
 	}
 
-	err = c.Set(key, val)
+	err = c.Set(key, val, opts...)
 	if err == nil || c.cfg.ignoreCacheSetErrors {
 		return val, false, nil
 	}

--- a/cache/memory_test.go
+++ b/cache/memory_test.go
@@ -18,18 +18,18 @@ type MockCache[K comparable, V any] struct {
 	WasPurged  bool
 }
 
-func (m *MockCache[K, V]) Get(key K) (V, bool, error) {
+func (m *MockCache[K, V]) Get(key K, opts ...cache.OperationOption) (V, bool, error) {
 	var v V
 	m.WasGot = append(m.WasGot, key)
 	return v, true, nil
 }
 
-func (m *MockCache[K, V]) Set(key K, _ V) error {
+func (m *MockCache[K, V]) Set(key K, _ V, opts ...cache.OperationOption) error {
 	m.WasSet = append(m.WasSet, key)
 	return nil
 }
 
-func (m *MockCache[K, V]) Delete(key K) error {
+func (m *MockCache[K, V]) Delete(key K, opts ...cache.OperationOption) error {
 	m.WasDeleted = append(m.WasDeleted, key)
 	return nil
 }
@@ -39,7 +39,7 @@ func (m *MockCache[K, V]) Purge() error {
 	return nil
 }
 
-func (m *MockCache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, wasFoundInCache bool, err error) {
+func (m *MockCache[K, V]) GetOrSet(key K, orSet func() (V, error), opts ...cache.OperationOption) (val V, wasFoundInCache bool, err error) {
 	v, err := orSet()
 	return v, false, err
 }

--- a/cache/option.go
+++ b/cache/option.go
@@ -67,3 +67,26 @@ func setCacheOpts[K comparable, V any](opts ...CacheOption[K, V]) cacheCfg[K, V]
 
 	return cfg
 }
+
+// OperationOption configures the behavior of individual cache operations (Get, Set, Delete, etc.).
+type OperationOption func(*operationCfg)
+
+type operationCfg struct {
+	prefix string
+}
+
+// WithPrefix prepends the given prefix to the hashed cache key for this operation.
+// Both Redis and in-memory backends hash keys via HashAny; the prefix is prepended to that hash.
+func WithPrefix(prefix string) OperationOption {
+	return func(cfg *operationCfg) {
+		cfg.prefix = prefix
+	}
+}
+
+func resolveOperationOpts(opts ...OperationOption) operationCfg {
+	var cfg operationCfg
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/cache/option_test.go
+++ b/cache/option_test.go
@@ -1,0 +1,156 @@
+//go:build test
+// +build test
+
+package cache_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/zendesk/go-generics/cache"
+	"github.com/zendesk/go-generics/internal/test"
+)
+
+func Test_WithPrefix_Redis_Set_Get(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
+
+	prefix := cache.WithPrefix("mcp:")
+
+	err := redisCache.Set("mykey", "myval", prefix)
+	test.CheckErr(err, "Failed to set", t)
+	test.CheckEqual(mockRedis.setKey, "SET key should have prefix", "mcp:"+cache.HashAny("mykey"), t)
+
+	_, _, err = redisCache.Get("mykey", prefix)
+	test.CheckErr(err, "Failed to get", t)
+	test.CheckEqual(mockRedis.getKey, "GET key should have prefix", "mcp:"+cache.HashAny("mykey"), t)
+}
+
+func Test_WithPrefix_Redis_GetOrSet(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
+
+	prefix := cache.WithPrefix("ns:")
+
+	// First Set so the mock has data, then GetOrSet should find it
+	err := redisCache.Set("key1", "existing", prefix)
+	test.CheckErr(err, "Failed to seed", t)
+
+	val, fromCache, err := redisCache.GetOrSet("key1", func() (string, error) {
+		return "should-not-be-used", nil
+	}, prefix)
+	test.CheckErr(err, "Failed GetOrSet", t)
+	test.CheckOk(fromCache, "Should be from cache", t)
+	test.CheckEqual(val, "Value", "existing", t)
+	test.CheckEqual(mockRedis.getKey, "GET key should have prefix", "ns:"+cache.HashAny("key1"), t)
+}
+
+func Test_WithPrefix_Redis_NoPrefix(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
+
+	// Without prefix, key should be plain hash
+	err := redisCache.Set("mykey", "myval")
+	test.CheckErr(err, "Failed to set", t)
+	test.CheckEqual(mockRedis.setKey, "SET key should be plain hash", cache.HashAny("mykey"), t)
+}
+
+func Test_WithPrefix_Redis_DifferentPrefixes_Isolate(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
+
+	// Set with prefix "a:"
+	err := redisCache.Set("key", "val-a", cache.WithPrefix("a:"))
+	test.CheckErr(err, "Failed to set with prefix a:", t)
+
+	// Set with prefix "b:" (overwrites mock's stored value)
+	err = redisCache.Set("key", "val-b", cache.WithPrefix("b:"))
+	test.CheckErr(err, "Failed to set with prefix b:", t)
+
+	// Get with prefix "b:" should return val-b (last written to mock)
+	got, _, err := redisCache.Get("key", cache.WithPrefix("b:"))
+	test.CheckErr(err, "Failed to get with prefix b:", t)
+	test.CheckEqual(got, "Value with prefix b:", "val-b", t)
+	test.CheckEqual(mockRedis.getKey, "GET key should have b: prefix", "b:"+cache.HashAny("key"), t)
+}
+
+func Test_WithPrefix_InMemory_Set_Get(t *testing.T) {
+	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
+
+	prefix := cache.WithPrefix("mcp:")
+
+	err := memCache.Set("mykey", "myval", prefix)
+	test.CheckErr(err, "Failed to set", t)
+
+	val, found, err := memCache.Get("mykey", prefix)
+	test.CheckErr(err, "Failed to get", t)
+	test.CheckOk(found, "Should be found", t)
+	test.CheckEqual(val, "Value", "myval", t)
+}
+
+func Test_WithPrefix_InMemory_Isolation(t *testing.T) {
+	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
+
+	// Set with prefix "a:"
+	err := memCache.Set("key", "val-a", cache.WithPrefix("a:"))
+	test.CheckErr(err, "Failed to set with prefix a:", t)
+
+	// Set with prefix "b:"
+	err = memCache.Set("key", "val-b", cache.WithPrefix("b:"))
+	test.CheckErr(err, "Failed to set with prefix b:", t)
+
+	// Get with "a:" should return val-a
+	val, found, err := memCache.Get("key", cache.WithPrefix("a:"))
+	test.CheckErr(err, "Failed to get with prefix a:", t)
+	test.CheckOk(found, "Should be found with prefix a:", t)
+	test.CheckEqual(val, "Value with prefix a:", "val-a", t)
+
+	// Get with "b:" should return val-b
+	val, found, err = memCache.Get("key", cache.WithPrefix("b:"))
+	test.CheckErr(err, "Failed to get with prefix b:", t)
+	test.CheckOk(found, "Should be found with prefix b:", t)
+	test.CheckEqual(val, "Value with prefix b:", "val-b", t)
+
+	// Get without prefix should not find either
+	_, found, err = memCache.Get("key")
+	test.CheckErr(err, "Failed to get without prefix", t)
+	test.CheckNotOk(found, "Should not be found without prefix", t)
+}
+
+func Test_WithPrefix_InMemory_Delete(t *testing.T) {
+	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
+
+	prefix := cache.WithPrefix("mcp:")
+
+	err := memCache.Set("key", "val", prefix)
+	test.CheckErr(err, "Failed to set", t)
+
+	err = memCache.Delete("key", prefix)
+	test.CheckErr(err, "Failed to delete", t)
+
+	_, found, err := memCache.Get("key", prefix)
+	test.CheckErr(err, "Failed to get after delete", t)
+	test.CheckNotOk(found, "Should not be found after delete", t)
+}
+
+func Test_WithPrefix_InMemory_GetOrSet(t *testing.T) {
+	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
+
+	prefix := cache.WithPrefix("ns:")
+
+	val, fromCache, err := memCache.GetOrSet("key1", func() (string, error) {
+		return "computed", nil
+	}, prefix)
+	test.CheckErr(err, "Failed GetOrSet", t)
+	test.CheckNotOk(fromCache, "Should not be from cache on first call", t)
+	test.CheckEqual(val, "Value", "computed", t)
+
+	// Second call should hit cache
+	val, fromCache, err = memCache.GetOrSet("key1", func() (string, error) {
+		return "should-not-be-used", nil
+	}, prefix)
+	test.CheckErr(err, "Failed GetOrSet (2)", t)
+	test.CheckOk(fromCache, "Should be from cache on second call", t)
+	test.CheckEqual(val, "Value", "computed", t)
+}

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -39,9 +39,9 @@ func NewRedisCache[K comparable, V any](ctx context.Context, client Redis, ttl t
 	return &cache
 }
 
-func (c *RedisCache[K, V]) Get(key K) (V, bool, error) {
+func (c *RedisCache[K, V]) Get(key K, opts ...OperationOption) (V, bool, error) {
 	var v V
-	bytes, err := c.client.Get(c.ctx, HashAny(key)).Bytes()
+	bytes, err := c.client.Get(c.ctx, buildKey(key, opts...)).Bytes()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return v, false, nil
@@ -61,12 +61,12 @@ func (c *RedisCache[K, V]) Get(key K) (V, bool, error) {
 	return v, true, nil
 }
 
-func (c *RedisCache[K, V]) Set(key K, val V) error {
+func (c *RedisCache[K, V]) Set(key K, val V, opts ...OperationOption) error {
 	bytes, err := serialize.NewSerializer[V]().FromDynamicType(val).ToBytes()
 	if err != nil {
 		return err
 	}
-	err = c.client.Set(c.ctx, HashAny(key), bytes, c.ttl).Err()
+	err = c.client.Set(c.ctx, buildKey(key, opts...), bytes, c.ttl).Err()
 
 	if err == nil || c.cfg.ignoreCacheSetErrors {
 		return nil
@@ -77,8 +77,8 @@ func (c *RedisCache[K, V]) Set(key K, val V) error {
 	return err
 }
 
-func (c *RedisCache[K, V]) Delete(key K) error {
-	return c.client.Del(c.ctx, HashAny(key)).Err()
+func (c *RedisCache[K, V]) Delete(key K, opts ...OperationOption) error {
+	return c.client.Del(c.ctx, buildKey(key, opts...)).Err()
 }
 
 func (c *RedisCache[K, V]) Purge() error {
@@ -86,8 +86,8 @@ func (c *RedisCache[K, V]) Purge() error {
 }
 
 // GetOrSet gets the value from cache for key K, or sets it value and return it via func orSet.
-func (c *RedisCache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, wasFoundInCache bool, err error) {
-	item, wasFound, err := c.Get(key)
+func (c *RedisCache[K, V]) GetOrSet(key K, orSet func() (V, error), opts ...OperationOption) (val V, wasFoundInCache bool, err error) {
+	item, wasFound, err := c.Get(key, opts...)
 	if wasFound {
 		return item, wasFound, err
 	}
@@ -97,7 +97,7 @@ func (c *RedisCache[K, V]) GetOrSet(key K, orSet func() (V, error)) (val V, wasF
 		return val, false, err
 	}
 
-	err = c.Set(key, val)
+	err = c.Set(key, val, opts...)
 	if err == nil || c.cfg.ignoreCacheSetErrors {
 		return val, false, nil
 	}

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -13,7 +13,7 @@ func HashAny(obj any) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// buildKey hashes the key and prepends an optional prefix from OperationOptions.
+// buildKey hashes the key and prepends an optional prefix from OperationOption.
 // Both Redis and in-memory backends use this to produce the internal storage key.
 func buildKey(key any, opts ...OperationOption) string {
 	cfg := resolveOperationOpts(opts...)

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -12,3 +12,10 @@ func HashAny(obj any) string {
 
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
+
+// buildKey hashes the key and prepends an optional prefix from OperationOptions.
+// Both Redis and in-memory backends use this to produce the internal storage key.
+func buildKey(key any, opts ...OperationOption) string {
+	cfg := resolveOperationOpts(opts...)
+	return cfg.prefix + HashAny(key)
+}


### PR DESCRIPTION
## Summary

- Adds `OperationOption` type with `WithPrefix(prefix string)` that can be passed to `Get`, `Set`, `Delete`, and `GetOrSet` on `Cache`, `CacheBackendAdapter`, and `EncryptedCache`
- `WithPrefix` prepends a string prefix to the hashed cache key, enabling key-based access control patterns (e.g., ElastiCache IAM ACLs that restrict access to keys matching `mcp:*`)
- Refactors `InMemoryCache` to use `ttlcache.Cache[string, V]` internally, so both Redis and in-memory backends hash keys to strings via `HashAny` — unified in a single `buildKey` function
- Existing callers are unaffected (variadic `...OperationOption` is optional)

## Motivation

The SSv2 MCP server uses ElastiCache with IAM key-based access control (`~mcp:* +@all`). The `RedisCache` previously ran all keys through `HashAny`, which stripped any caller-provided prefix. This change lets callers pass `WithPrefix("mcp:")` so the prefix survives to Redis and matches the ACL.

## Test plan

- [ ] Existing unit tests pass (`go test -tags test ./cache/...`)
- [ ] Fuzz tests pass
- [ ] Verify SSv2 MCP server can use `WithPrefix("mcp:")` to write keys that match ElastiCache ACL