### PR TITLE
Add WithPrefix option to RedisLockBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,8 +501,13 @@ client := goredislib.NewClient(&goredislib.Options{
     Addr: "localhost:6379",
 })
 pool := goredis.NewPool(client)
-backend := concurrency.NewRedisLockBackend(pool)
+backend := concurrency.NewRedisLockBackend([]redis.Pool{pool})
 manager := concurrency.NewLockManager(backend)
+
+// To scope all locks under a key prefix (e.g. when the Redis user's ACL is
+// limited to a prefix such as `service-name:*`), pass concurrency.WithPrefix:
+//
+//   backend := concurrency.NewRedisLockBackend([]redis.Pool{pool}, concurrency.WithPrefix("service-name:"))
 
 ctx := context.Background()
 lockKey := "distributed-resource-456"

--- a/README.md
+++ b/README.md
@@ -492,8 +492,10 @@ Example 2: Redis-based distributed locking
 
 ```go
 import (
+    redsyncredis "github.com/go-redsync/redsync/v4/redis"
     "github.com/go-redsync/redsync/v4/redis/goredis/v9"
     goredislib "github.com/redis/go-redis/v9"
+    "github.com/zendesk/go-generics/concurrency"
 )
 
 // Create Redis client and lock backend
@@ -501,13 +503,13 @@ client := goredislib.NewClient(&goredislib.Options{
     Addr: "localhost:6379",
 })
 pool := goredis.NewPool(client)
-backend := concurrency.NewRedisLockBackend([]redis.Pool{pool})
+backend := concurrency.NewRedisLockBackend([]redsyncredis.Pool{pool})
 manager := concurrency.NewLockManager(backend)
 
 // To scope all locks under a key prefix (e.g. when the Redis user's ACL is
 // limited to a prefix such as `service-name:*`), pass concurrency.WithPrefix:
 //
-//   backend := concurrency.NewRedisLockBackend([]redis.Pool{pool}, concurrency.WithPrefix("service-name:"))
+//   backend := concurrency.NewRedisLockBackend([]redsyncredis.Pool{pool}, concurrency.WithPrefix("service-name:"))
 
 ctx := context.Background()
 lockKey := "distributed-resource-456"

--- a/concurrency/option.go
+++ b/concurrency/option.go
@@ -1,0 +1,26 @@
+package concurrency
+
+// LockBackendOption configures a lock backend at construction time.
+type LockBackendOption func(*lockBackendCfg)
+
+type lockBackendCfg struct {
+	prefix string
+}
+
+// WithPrefix prepends the given prefix to every lock name obtained through the backend.
+// This is useful when the underlying store (e.g. AWS ElastiCache) enforces ACLs on key
+// patterns — every lock key will start with the configured prefix so it satisfies a
+// pattern like `service-name:*`.
+func WithPrefix(prefix string) LockBackendOption {
+	return func(cfg *lockBackendCfg) {
+		cfg.prefix = prefix
+	}
+}
+
+func resolveLockBackendOpts(opts ...LockBackendOption) lockBackendCfg {
+	var cfg lockBackendCfg
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/concurrency/redis.go
+++ b/concurrency/redis.go
@@ -11,12 +11,16 @@ import (
 
 type RedisLockBackend struct {
 	locker *redsync.Redsync
+	prefix string
 }
 
-func NewRedisLockBackend(pools ...redis.Pool) *RedisLockBackend {
-	locker := redsync.New(pools...)
+// NewRedisLockBackend creates a RedisLockBackend backed by one or more redsync pools.
+// LockBackendOption values (e.g. WithPrefix) may be supplied via the opts parameter.
+func NewRedisLockBackend(pools []redis.Pool, opts ...LockBackendOption) *RedisLockBackend {
+	cfg := resolveLockBackendOpts(opts...)
 	return &RedisLockBackend{
-		locker: locker,
+		locker: redsync.New(pools...),
+		prefix: cfg.prefix,
 	}
 }
 
@@ -25,9 +29,10 @@ type redisMutex struct {
 }
 
 func (r *RedisLockBackend) ObtainLock(ctx context.Context, name string, ttl time.Duration) (Lock, error) {
-	mutex := r.locker.NewMutex(name, redsync.WithExpiry(ttl))
+	key := r.prefix + name
+	mutex := r.locker.NewMutex(key, redsync.WithExpiry(ttl))
 	if err := mutex.LockContext(ctx); err != nil {
-		return nil, WrapError(ErrorLockNotAcquired, fmt.Sprintf("failed to obtain lock for name %s", name))
+		return nil, WrapError(ErrorLockNotAcquired, fmt.Sprintf("failed to obtain lock for name %s", key))
 	}
 	return &redisMutex{mutex: mutex}, nil
 }

--- a/concurrency/redis.go
+++ b/concurrency/redis.go
@@ -2,6 +2,7 @@ package concurrency
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,7 +15,7 @@ type RedisLockBackend struct {
 	prefix string
 }
 
-// NewRedisLockBackend creates a RedisLockBackend backed by one or more redsync pools.
+// NewRedisLockBackend creates a RedisLockBackend backed by the provided redsync pools.
 // LockBackendOption values (e.g. WithPrefix) may be supplied via the opts parameter.
 func NewRedisLockBackend(pools []redis.Pool, opts ...LockBackendOption) *RedisLockBackend {
 	cfg := resolveLockBackendOpts(opts...)
@@ -32,7 +33,13 @@ func (r *RedisLockBackend) ObtainLock(ctx context.Context, name string, ttl time
 	key := r.prefix + name
 	mutex := r.locker.NewMutex(key, redsync.WithExpiry(ttl))
 	if err := mutex.LockContext(ctx); err != nil {
-		return nil, WrapError(ErrorLockNotAcquired, fmt.Sprintf("failed to obtain lock for name %s", key))
+		// Preserve the underlying error (e.g. Redis ACL NOPERM, network failures) so
+		// callers can inspect it, while still matching errors.Is(err, ErrorLockNotAcquired)
+		// for the common contention case.
+		return nil, errors.Join(
+			ErrorLockNotAcquired,
+			fmt.Errorf("failed to obtain lock for name %s (key %s): %w", name, key, err),
+		)
 	}
 	return &redisMutex{mutex: mutex}, nil
 }

--- a/concurrency/redis_integration_test.go
+++ b/concurrency/redis_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	redsyncredis "github.com/go-redsync/redsync/v4/redis"
 	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
 	goredislib "github.com/redis/go-redis/v9"
 )
@@ -45,7 +46,7 @@ func TestRedisLockBackend_Integration(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	ctx := context.Background()
 	name := "test-redis-lock"
 	ttl := 100 * time.Millisecond
@@ -78,7 +79,7 @@ func TestRedisLockBackend_LockConflicts(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	ctx := context.Background()
 	name := "conflict-redis-lock"
 	ttl := 10 * time.Second
@@ -116,7 +117,7 @@ func TestRedisLockBackend_TTLExpiration(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	ctx := context.Background()
 	name := "expire-redis-lock"
 	shortTTL := 100 * time.Millisecond
@@ -148,7 +149,7 @@ func TestRedisLockBackend_RefreshOperations(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	ctx := context.Background()
 	name := "refresh-redis-lock"
 	ttl := 200 * time.Millisecond
@@ -180,7 +181,7 @@ func TestRedisLockBackend_ConcurrentAccess(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	ctx := context.Background()
 	name := "concurrent-redis-lock"
 	ttl := 20 * time.Second
@@ -231,7 +232,7 @@ func TestRedisLockBackend_MultipleLocks(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	ctx := context.Background()
 	ttl := 200 * time.Millisecond
 
@@ -266,7 +267,7 @@ func TestRedisLockBackend_LockAfterRelease(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	ctx := context.Background()
 	name := "reuse-redis-lock"
 	ttl := 100 * time.Millisecond
@@ -295,7 +296,7 @@ func TestRedisLockBackend_WithLockManager(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	manager := NewLockManager(backend)
 	ctx := context.Background()
 	key := "test-redis-manager-key"
@@ -329,7 +330,7 @@ func TestRedisLockBackend_ContextCancellation(t *testing.T) {
 	defer client.Close()
 
 	pool := goredis.NewPool(client)
-	backend := NewRedisLockBackend(pool)
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool})
 	name := "context-cancel-lock"
 	ttl := 100 * time.Millisecond
 
@@ -361,4 +362,48 @@ func TestRedisLockBackend_ContextCancellation(t *testing.T) {
 	if err := lock.Release(normalCtx); err != nil {
 		t.Fatalf("failed to release Redis lock: %v", err)
 	}
+}
+
+func TestRedisLockBackend_WithPrefix(t *testing.T) {
+	client := setupRedisClient(t)
+	defer client.Close()
+
+	pool := goredis.NewPool(client)
+	prefix := "svc:"
+	backend := NewRedisLockBackend([]redsyncredis.Pool{pool}, WithPrefix(prefix))
+	ctx := context.Background()
+	name := "prefix-redis-lock"
+	ttl := 10 * time.Second
+
+	lock, err := backend.ObtainLock(ctx, name, ttl)
+	if err != nil {
+		t.Fatalf("failed to obtain prefixed Redis lock: %v", err)
+	}
+	defer lock.Release(ctx)
+
+	// The prefixed key should exist; the unprefixed key should not.
+	if exists, err := client.Exists(ctx, prefix+name).Result(); err != nil {
+		t.Fatalf("failed to check prefixed key existence: %v", err)
+	} else if exists != 1 {
+		t.Fatalf("expected prefixed key %q to exist, got exists=%d", prefix+name, exists)
+	}
+	if exists, err := client.Exists(ctx, name).Result(); err != nil {
+		t.Fatalf("failed to check unprefixed key existence: %v", err)
+	} else if exists != 0 {
+		t.Fatalf("expected unprefixed key %q to not exist, got exists=%d", name, exists)
+	}
+
+	// A second backend with the same prefix should conflict on the same name.
+	backend2 := NewRedisLockBackend([]redsyncredis.Pool{pool}, WithPrefix(prefix))
+	if _, err := backend2.ObtainLock(ctx, name, ttl); !errors.Is(err, ErrorLockNotAcquired) {
+		t.Fatalf("expected ErrorLockNotAcquired from conflicting prefixed lock, got: %v", err)
+	}
+
+	// A backend with a different prefix should not conflict.
+	backend3 := NewRedisLockBackend([]redsyncredis.Pool{pool}, WithPrefix("other:"))
+	lock3, err := backend3.ObtainLock(ctx, name, ttl)
+	if err != nil {
+		t.Fatalf("expected independent lock under different prefix, got: %v", err)
+	}
+	_ = lock3.Release(ctx)
 }

--- a/concurrency/redis_integration_test.go
+++ b/concurrency/redis_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -395,8 +396,14 @@ func TestRedisLockBackend_WithPrefix(t *testing.T) {
 
 	// A second backend with the same prefix should conflict on the same name.
 	backend2 := NewRedisLockBackend([]redsyncredis.Pool{pool}, WithPrefix(prefix))
-	if _, err := backend2.ObtainLock(ctx, name, ttl); !errors.Is(err, ErrorLockNotAcquired) {
+	_, err = backend2.ObtainLock(ctx, name, ttl)
+	if !errors.Is(err, ErrorLockNotAcquired) {
 		t.Fatalf("expected ErrorLockNotAcquired from conflicting prefixed lock, got: %v", err)
+	}
+	// The underlying redsync error should also be surfaced so callers can diagnose
+	// non-contention failures (e.g. ACL NOPERM, network issues).
+	if msg := err.Error(); !strings.Contains(msg, name) || !strings.Contains(msg, prefix+name) {
+		t.Fatalf("expected error to include both name %q and key %q, got: %s", name, prefix+name, msg)
 	}
 
 	// A backend with a different prefix should not conflict.


### PR DESCRIPTION
## Summary

- Add `concurrency.WithPrefix(prefix)` functional option that prepends a prefix to every lock name obtained from a `RedisLockBackend`.
- This enables compatibility with Redis ACLs that restrict access to keys matching a specific pattern (e.g. `service-name:*` on AWS ElastiCache). Without it, callers get `NOPERM this user has no permissions to access one of the keys used as arguments` when the underlying user ACL does not permit the bare lock name.
- Follows the same pattern already used by `cache.WithPrefix` and `ratelimit.WithPrefixOption`.

## Breaking change

`NewRedisLockBackend` signature changes from:

```go
func NewRedisLockBackend(pools ...redis.Pool) *RedisLockBackend
```

to:

```go
func NewRedisLockBackend(pools []redis.Pool, opts ...LockBackendOption) *RedisLockBackend
```

This is required to make the options parameter unambiguous. Callers need to wrap their pool in a slice literal:

```go
// before
backend := concurrency.NewRedisLockBackend(pool)
// after
backend := concurrency.NewRedisLockBackend([]redis.Pool{pool})
// with prefix
backend := concurrency.NewRedisLockBackend([]redis.Pool{pool}, concurrency.WithPrefix("service-name:"))
```

Known consumers: only `secret-service-v2-api` uses `NewRedisLockBackend` outside this repo. A follow-up PR there will adopt the new signature and add a prefix.

## Test plan

- [x] `go build -tags=redis,test ./...`
- [x] `go test -tags=test ./...` — all existing tests pass
- [x] Updated all nine `NewRedisLockBackend(pool)` callers in `redis_integration_test.go`
- [x] New integration test `TestRedisLockBackend_WithPrefix` verifies:
  - Prefixed key actually lands in Redis under `prefix+name`
  - Unprefixed key does not exist
  - Two backends with the same prefix conflict on the same name
  - Two backends with different prefixes do not conflict
- [ ] Run `go test -tags=redis,test ./concurrency/...` locally with a real Redis instance (integration tests are behind the `redis` build tag)