### PR TITLE
Add WithAllowLegacyParameters + WithLegacyNonce for pre-#18 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,3 +839,39 @@ Encrypt with an auto-generated secure password + nonce.
     }
 ```
 
+### Validation and legacy parameters
+
+`New`, `NewWithPassword`, and `NewWithPasswordNonce` reject salts shorter than
+`MinSaltLength` (16 bytes) and iteration counts below `MinIterations` (100 000).
+New deployments should always meet these minimums.
+
+Existing production systems that persisted data using a shorter salt or a lower
+iteration count cannot change those parameters without a coordinated data
+re-encryption. For those cases, pass `WithAllowLegacyParameters()` to bypass the
+validation at construction time:
+
+```go
+ed, err := encryption.NewWithPassword[Foo](
+    []byte("password"),
+    legacySalt,         // e.g. a 10-byte salt persisted before MinSaltLength existed
+    legacyIterations,   // e.g. 4096, below the current MinIterations
+    encryption.WithAllowLegacyParameters(),
+)
+```
+
+When constructing an `EncryptedCache`, forward the option via
+`cache.WithEncryptionOptions`:
+
+```go
+c, err := cache.NewEncryptedCacheWithPassword[string, string](
+    backend,
+    []byte("password"),
+    legacySalt,
+    legacyIterations,
+    cache.WithEncryptionOptions[string, string](encryption.WithAllowLegacyParameters()),
+)
+```
+
+Do not use this option for new data. It exists only to keep already-persisted
+ciphertext readable while callers plan a migration to compliant parameters.
+

--- a/README.md
+++ b/README.md
@@ -875,3 +875,38 @@ c, err := cache.NewEncryptedCacheWithPassword[string, string](
 Do not use this option for new data. It exists only to keep already-persisted
 ciphertext readable while callers plan a migration to compliant parameters.
 
+### Reading data written by pre-2026-03 releases (`WithLegacyNonce`)
+
+Prior to the AES-GCM nonce-reuse fix, the encryptor stored a single nonce on the
+struct and produced ciphertext without a nonce prefix: `[ciphertext|tag]`. The
+current version generates a fresh nonce for every call and prepends it:
+`[nonce|ciphertext|tag]`. These two wire formats are incompatible — a default
+current `Decrypt` will treat the first 12 bytes of legacy ciphertext as a nonce
+and fail authentication.
+
+For callers that must read rows written by the old format, pass
+`encryption.WithLegacyNonce(nonce)` with the exact 12-byte nonce the data was
+originally encrypted with:
+
+```go
+ed, err := encryption.NewWithPassword[Foo](
+    password,
+    legacySalt,
+    legacyIterations,
+    encryption.WithAllowLegacyParameters(), // if salt/iterations are also legacy
+    encryption.WithLegacyNonce(legacyNonce),
+)
+```
+
+**Not recommended.** `WithLegacyNonce` fixes the AES-GCM nonce for every call,
+which reintroduces the exact vulnerability #18 fixed: reusing a nonce under the
+same key catastrophically breaks both confidentiality and authenticity. Treat a
+legacy-nonce encryptor as read-only whenever possible — decrypt old rows,
+re-encrypt them with a default (per-call random nonce) encryptor, and retire
+the legacy option. Only continue to *write* with `WithLegacyNonce` when a
+migration cannot be scheduled, and keep such writes tightly scoped.
+
+`WithLegacyNonce` is *technically* forwardable through `cache.WithEncryptionOptions`,
+but don't do that: encrypted caches are ephemeral and should invalidate and
+re-encrypt rather than permanently adopt a fixed-nonce encryptor.
+

--- a/cache/encrypted_cache.go
+++ b/cache/encrypted_cache.go
@@ -30,7 +30,7 @@ func NewEncryptedCache[K comparable, V any](backend CacheBackendAdapter[K, []byt
 func NewEncryptedCacheWithIterations[K comparable, V any](backend CacheBackendAdapter[K, []byte], salt []byte, iterations int, opts ...CacheBackendOption[K, V]) (*EncryptedCache[K, V], error) {
 	cfg := setBackendOpts(opts...)
 
-	ed, err := encryption.New[V](salt, iterations)
+	ed, err := encryption.New[V](salt, iterations, cfg.encryptionOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new encryptor: %w", err)
 	}
@@ -48,7 +48,7 @@ func NewEncryptedCacheWithIterations[K comparable, V any](backend CacheBackendAd
 func NewEncryptedCacheWithPassword[K comparable, V any](backend CacheBackendAdapter[K, []byte], password, salt []byte, iterations int, opts ...CacheBackendOption[K, V]) (*EncryptedCache[K, V], error) {
 	cfg := setBackendOpts(opts...)
 
-	ed, err := encryption.NewWithPassword[V](password, salt, iterations)
+	ed, err := encryption.NewWithPassword[V](password, salt, iterations, cfg.encryptionOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new encryptor: %w", err)
 	}

--- a/cache/encrypted_cache.go
+++ b/cache/encrypted_cache.go
@@ -20,13 +20,21 @@ type EncryptedCache[K comparable, V any] struct {
 	cfg     cacheBackendCfg[K, V]
 }
 
-// NewEncryptedCache provides a new EncryptedCache with default configurations that provides a balance of performance and security. Selecting a # of iterations that is difficult to guess
-// and high enough to make encrypt / decrypt durations sufficiently long to deter brute force attack is recommended. Minimum 2048 iterations is recommended
+// NewEncryptedCache provides a new EncryptedCache with default configurations
+// that balance performance and security.
+//
+// salt must be at least encryption.MinSaltLength (16) bytes and iterations
+// must be at least encryption.MinIterations (100 000); otherwise construction
+// fails. Legacy persisted data that predates these minimums can opt out by
+// passing cache.WithEncryptionOptions(encryption.WithAllowLegacyParameters()).
 func NewEncryptedCache[K comparable, V any](backend CacheBackendAdapter[K, []byte], salt []byte, iterations int, opts ...CacheBackendOption[K, V]) (*EncryptedCache[K, V], error) {
 	return NewEncryptedCacheWithIterations[K, V](backend, salt, iterations, opts...)
 }
 
-// NewEncryptedCacheWithIterations allows the user to specify a number of iterations which influences work factor for the cache.
+// NewEncryptedCacheWithIterations allows the user to specify a number of
+// iterations which influences work factor for the cache. iterations must be at
+// least encryption.MinIterations (100 000) unless the caller opts out via
+// cache.WithEncryptionOptions(encryption.WithAllowLegacyParameters()).
 func NewEncryptedCacheWithIterations[K comparable, V any](backend CacheBackendAdapter[K, []byte], salt []byte, iterations int, opts ...CacheBackendOption[K, V]) (*EncryptedCache[K, V], error) {
 	cfg := setBackendOpts(opts...)
 

--- a/cache/encrypted_cache_test.go
+++ b/cache/encrypted_cache_test.go
@@ -206,6 +206,61 @@ func BenchmarkDecrypt(b *testing.B) {
 	}
 }
 
+func TestNewEncryptedCache_WithEncryptionOptions_AllowsLegacyParameters(t *testing.T) {
+	// A 10-byte salt violates MinSaltLength; low iterations violate MinIterations.
+	// Forwarding WithAllowLegacyParameters via WithEncryptionOptions must bypass both.
+	shortSalt := []byte("saltyvalu2")
+	lowIterations := 4096
+
+	ttlCache := cache.NewInMemoryCache[string, []byte](10 * time.Second)
+
+	// Without the option, construction must fail.
+	if _, err := cache.NewEncryptedCache[string, string](ttlCache, shortSalt, lowIterations); err == nil {
+		t.Fatal("expected error for short salt + low iterations without opt-out, got nil")
+	}
+
+	// With the option, construction must succeed and the cache must round-trip.
+	c, err := cache.NewEncryptedCache[string, string](
+		ttlCache,
+		shortSalt,
+		lowIterations,
+		cache.WithEncryptionOptions[string, string](encryption.WithAllowLegacyParameters()),
+	)
+	test.CheckErr(err, "Unexpected err constructing encrypted cache with legacy parameters opt-out", t)
+	test.ExpectNotNil("cache", c, t)
+
+	err = c.Set("key", "value")
+	test.CheckErr(err, "Unexpected err on Set", t)
+
+	value, _, err := c.Get("key")
+	test.CheckErr(err, "Unexpected err on Get", t)
+	test.CheckEqual(value, "value", "value", t)
+}
+
+func TestNewEncryptedCacheWithPassword_WithEncryptionOptions_AllowsLegacyParameters(t *testing.T) {
+	shortSalt := []byte("saltyvalu2")
+	lowIterations := 4096
+
+	ttlCache := cache.NewInMemoryCache[string, []byte](10 * time.Second)
+
+	c, err := cache.NewEncryptedCacheWithPassword[string, string](
+		ttlCache,
+		[]byte("password"),
+		shortSalt,
+		lowIterations,
+		cache.WithEncryptionOptions[string, string](encryption.WithAllowLegacyParameters()),
+	)
+	test.CheckErr(err, "Unexpected err constructing password-encrypted cache with legacy parameters opt-out", t)
+	test.ExpectNotNil("cache", c, t)
+
+	err = c.Set("key", "value")
+	test.CheckErr(err, "Unexpected err on Set", t)
+
+	value, _, err := c.Get("key")
+	test.CheckErr(err, "Unexpected err on Get", t)
+	test.CheckEqual(value, "value", "value", t)
+}
+
 func TestPurge(t *testing.T) {
 	ttlCache := cache.NewInMemoryCache[string, []byte](10 * time.Second)
 

--- a/cache/option.go
+++ b/cache/option.go
@@ -1,10 +1,13 @@
 package cache
 
+import "github.com/zendesk/go-generics/encryption"
+
 type cacheBackendCfg[K comparable, V any] struct {
 	failThroughCache     CacheBackendAdapter[K, V]
 	observer             CacheObserver[K]
 	capacity             uint64
 	ignoreCacheSetErrors bool
+	encryptionOpts       []encryption.Option
 }
 
 type CacheBackendOption[K comparable, V any] func(cfg cacheBackendCfg[K, V]) cacheBackendCfg[K, V]
@@ -42,6 +45,16 @@ func WithCapacity[K comparable, V any](maxObjects uint64) CacheBackendOption[K, 
 func IgnoreCacheSetErrors[K comparable, V any]() CacheBackendOption[K, V] {
 	return func(cfg cacheBackendCfg[K, V]) cacheBackendCfg[K, V] {
 		cfg.ignoreCacheSetErrors = true
+		return cfg
+	}
+}
+
+// WithEncryptionOptions forwards the given encryption.Option values to the
+// underlying EncryptorDecryptor used by NewEncryptedCache* constructors.
+// It has no effect on non-encrypted caches.
+func WithEncryptionOptions[K comparable, V any](opts ...encryption.Option) CacheBackendOption[K, V] {
+	return func(cfg cacheBackendCfg[K, V]) cacheBackendCfg[K, V] {
+		cfg.encryptionOpts = append(cfg.encryptionOpts, opts...)
 		return cfg
 	}
 }

--- a/encryption/encryptor_decryptor.go
+++ b/encryption/encryptor_decryptor.go
@@ -49,6 +49,20 @@ func validateIterations(iterations int) error {
 	return nil
 }
 
+// validateParameterSanity enforces the absolute minimum constraints that must
+// hold regardless of WithAllowLegacyParameters. pbkdf2.Key does not validate
+// its inputs and produces meaningless / trivially-derived keys when iterations
+// is non-positive or salt is empty, so these checks are *not* opt-out-able.
+func validateParameterSanity(salt []byte, iterations int) error {
+	if iterations <= 0 {
+		return fmt.Errorf("%w: must be greater than 0, got %d", ErrIterationsTooLow, iterations)
+	}
+	if len(salt) == 0 {
+		return fmt.Errorf("%w: must not be empty", ErrSaltTooShort)
+	}
+	return nil
+}
+
 // New creates a new EncryptorDecryptor instance with a random password.
 // A fresh random nonce is generated for each Encrypt call and prepended to the ciphertext.
 //
@@ -58,6 +72,9 @@ func validateIterations(iterations int) error {
 // see that option's documentation for the security implications.
 func New[T any](salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
 	cfg := resolveOptions(opts...)
+	if err := validateParameterSanity(salt, iterations); err != nil {
+		return nil, err
+	}
 	if !cfg.allowLegacyParameters {
 		if err := validateIterations(iterations); err != nil {
 			return nil, err
@@ -100,6 +117,9 @@ func New[T any](salt []byte, iterations int, opts ...Option) (*EncryptorDecrypto
 // see that option's documentation for the security implications.
 func NewWithPassword[T any](password, salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
 	cfg := resolveOptions(opts...)
+	if err := validateParameterSanity(salt, iterations); err != nil {
+		return nil, err
+	}
 	if !cfg.allowLegacyParameters {
 		if err := validateIterations(iterations); err != nil {
 			return nil, err

--- a/encryption/encryptor_decryptor.go
+++ b/encryption/encryptor_decryptor.go
@@ -20,14 +20,19 @@ const MinIterations = 100_000
 
 var ErrSaltTooShort = errors.New("salt too short")
 
-// Deprecated: ErrInvalidNonce is no longer returned by any constructor. Nonces are now
-// generated per-Encrypt call. Kept for backward compatibility.
+// ErrInvalidNonce is returned when a caller supplies a fixed legacy nonce via
+// WithLegacyNonce whose length is not NonceLength. The default (no legacy nonce)
+// path generates nonces internally and never returns this error.
 var ErrInvalidNonce = errors.New("invalid nonce length")
 var ErrIterationsTooLow = errors.New("iterations too low")
 var ErrCiphertextTooShort = errors.New("ciphertext too short")
 
 type EncryptorDecryptor[T any] struct {
 	aesgcm cipher.AEAD
+	// legacyNonce, when non-nil, selects the pre-#18 wire format: a fixed
+	// caller-supplied nonce is reused for every Encrypt/Decrypt call and the
+	// ciphertext is NOT self-describing (no nonce prefix). See WithLegacyNonce.
+	legacyNonce []byte
 }
 
 func validateSalt(salt []byte) error {
@@ -49,6 +54,8 @@ func validateIterations(iterations int) error {
 //
 // Pass WithAllowLegacyParameters to bypass salt-length and iteration-count
 // validation; see that option's documentation for when it is appropriate.
+// Pass WithLegacyNonce only to read ciphertext written by pre-#18 go-generics;
+// see that option's documentation for the security implications.
 func New[T any](salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
 	cfg := resolveOptions(opts...)
 	if !cfg.allowLegacyParameters {
@@ -58,6 +65,9 @@ func New[T any](salt []byte, iterations int, opts ...Option) (*EncryptorDecrypto
 		if err := validateSalt(salt); err != nil {
 			return nil, err
 		}
+	}
+	if cfg.legacyNonce != nil && len(cfg.legacyNonce) != NonceLength {
+		return nil, fmt.Errorf("%w: must be exactly %d bytes, got %d", ErrInvalidNonce, NonceLength, len(cfg.legacyNonce))
 	}
 
 	password := make([]byte, 2048)
@@ -77,7 +87,7 @@ func New[T any](salt []byte, iterations int, opts ...Option) (*EncryptorDecrypto
 		return nil, fmt.Errorf("error creating new GCM: %w", err)
 	}
 
-	return &EncryptorDecryptor[T]{aesgcm: aesgcm}, nil
+	return &EncryptorDecryptor[T]{aesgcm: aesgcm, legacyNonce: cfg.legacyNonce}, nil
 }
 
 // NewWithPassword creates a new EncryptorDecryptor instance with a specified password. Use this if
@@ -86,6 +96,8 @@ func New[T any](salt []byte, iterations int, opts ...Option) (*EncryptorDecrypto
 //
 // Pass WithAllowLegacyParameters to bypass salt-length and iteration-count
 // validation; see that option's documentation for when it is appropriate.
+// Pass WithLegacyNonce only to read ciphertext written by pre-#18 go-generics;
+// see that option's documentation for the security implications.
 func NewWithPassword[T any](password, salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
 	cfg := resolveOptions(opts...)
 	if !cfg.allowLegacyParameters {
@@ -95,6 +107,9 @@ func NewWithPassword[T any](password, salt []byte, iterations int, opts ...Optio
 		if err := validateSalt(salt); err != nil {
 			return nil, err
 		}
+	}
+	if cfg.legacyNonce != nil && len(cfg.legacyNonce) != NonceLength {
+		return nil, fmt.Errorf("%w: must be exactly %d bytes, got %d", ErrInvalidNonce, NonceLength, len(cfg.legacyNonce))
 	}
 
 	aesKey := pbkdf2.Key(password, salt, iterations, 32, sha256.New)
@@ -109,13 +124,16 @@ func NewWithPassword[T any](password, salt []byte, iterations int, opts ...Optio
 		return nil, fmt.Errorf("error creating new GCM: %w", err)
 	}
 
-	return &EncryptorDecryptor[T]{aesgcm: aesgcm}, nil
+	return &EncryptorDecryptor[T]{aesgcm: aesgcm, legacyNonce: cfg.legacyNonce}, nil
 }
 
 // Deprecated: NewWithPasswordNonce is replaced by NewWithPassword. Nonces are now generated
 // per-Encrypt call and prepended to the ciphertext. The nonce parameter is accepted only for
 // API compatibility, is completely ignored, and is not validated (any value, including nil, is
 // accepted and unused).
+//
+// To decrypt ciphertext written by pre-#18 go-generics (fixed-nonce, no prefix wire format),
+// callers must pass WithLegacyNonce(theirNonce) explicitly.
 func NewWithPasswordNonce[T any](password, _ /*nonce*/, salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
 	return NewWithPassword[T](password, salt, iterations, opts...)
 }
@@ -126,6 +144,11 @@ func (e *EncryptorDecryptor[T]) Encrypt(value T) ([]byte, error) {
 	bytes, err := serialize.NewSerializer[wrapper[T]]().FromDynamicType(w).ToBytes()
 	if err != nil {
 		return nil, err
+	}
+
+	if e.legacyNonce != nil {
+		// Legacy wire format: fixed nonce, not prepended. Produces [ciphertext|tag].
+		return e.aesgcm.Seal(nil, e.legacyNonce, bytes, nil), nil
 	}
 
 	nonce := make([]byte, e.aesgcm.NonceSize())
@@ -139,13 +162,24 @@ func (e *EncryptorDecryptor[T]) Encrypt(value T) ([]byte, error) {
 
 func (e *EncryptorDecryptor[T]) Decrypt(ciphertext []byte) (T, error) {
 	var t T
-	nonceSize := e.aesgcm.NonceSize()
-	minLen := nonceSize + e.aesgcm.Overhead()
-	if len(ciphertext) < minLen {
-		return t, fmt.Errorf("%w: expected at least %d bytes, got %d", ErrCiphertextTooShort, minLen, len(ciphertext))
+
+	var nonce, ct []byte
+	if e.legacyNonce != nil {
+		// Legacy wire format: ciphertext is [ciphertext|tag]; nonce is the fixed one.
+		minLen := e.aesgcm.Overhead()
+		if len(ciphertext) < minLen {
+			return t, fmt.Errorf("%w: expected at least %d bytes, got %d", ErrCiphertextTooShort, minLen, len(ciphertext))
+		}
+		nonce, ct = e.legacyNonce, ciphertext
+	} else {
+		nonceSize := e.aesgcm.NonceSize()
+		minLen := nonceSize + e.aesgcm.Overhead()
+		if len(ciphertext) < minLen {
+			return t, fmt.Errorf("%w: expected at least %d bytes, got %d", ErrCiphertextTooShort, minLen, len(ciphertext))
+		}
+		nonce, ct = ciphertext[:nonceSize], ciphertext[nonceSize:]
 	}
 
-	nonce, ct := ciphertext[:nonceSize], ciphertext[nonceSize:]
 	decryptedBytes, err := e.aesgcm.Open(nil, nonce, ct, nil)
 	if err != nil {
 		return t, fmt.Errorf("error decrypting ciphertext: %w", err)

--- a/encryption/encryptor_decryptor.go
+++ b/encryption/encryptor_decryptor.go
@@ -46,12 +46,18 @@ func validateIterations(iterations int) error {
 
 // New creates a new EncryptorDecryptor instance with a random password.
 // A fresh random nonce is generated for each Encrypt call and prepended to the ciphertext.
-func New[T any](salt []byte, iterations int) (*EncryptorDecryptor[T], error) {
-	if err := validateIterations(iterations); err != nil {
-		return nil, err
-	}
-	if err := validateSalt(salt); err != nil {
-		return nil, err
+//
+// Pass WithAllowLegacyParameters to bypass salt-length and iteration-count
+// validation; see that option's documentation for when it is appropriate.
+func New[T any](salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
+	cfg := resolveOptions(opts...)
+	if !cfg.allowLegacyParameters {
+		if err := validateIterations(iterations); err != nil {
+			return nil, err
+		}
+		if err := validateSalt(salt); err != nil {
+			return nil, err
+		}
 	}
 
 	password := make([]byte, 2048)
@@ -77,12 +83,18 @@ func New[T any](salt []byte, iterations int) (*EncryptorDecryptor[T], error) {
 // NewWithPassword creates a new EncryptorDecryptor instance with a specified password. Use this if
 // you intend to persist whatever is encrypted. A fresh random nonce is generated for each Encrypt
 // call and prepended to the ciphertext.
-func NewWithPassword[T any](password, salt []byte, iterations int) (*EncryptorDecryptor[T], error) {
-	if err := validateIterations(iterations); err != nil {
-		return nil, err
-	}
-	if err := validateSalt(salt); err != nil {
-		return nil, err
+//
+// Pass WithAllowLegacyParameters to bypass salt-length and iteration-count
+// validation; see that option's documentation for when it is appropriate.
+func NewWithPassword[T any](password, salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
+	cfg := resolveOptions(opts...)
+	if !cfg.allowLegacyParameters {
+		if err := validateIterations(iterations); err != nil {
+			return nil, err
+		}
+		if err := validateSalt(salt); err != nil {
+			return nil, err
+		}
 	}
 
 	aesKey := pbkdf2.Key(password, salt, iterations, 32, sha256.New)
@@ -104,8 +116,8 @@ func NewWithPassword[T any](password, salt []byte, iterations int) (*EncryptorDe
 // per-Encrypt call and prepended to the ciphertext. The nonce parameter is accepted only for
 // API compatibility, is completely ignored, and is not validated (any value, including nil, is
 // accepted and unused).
-func NewWithPasswordNonce[T any](password, _ /*nonce*/, salt []byte, iterations int) (*EncryptorDecryptor[T], error) {
-	return NewWithPassword[T](password, salt, iterations)
+func NewWithPasswordNonce[T any](password, _ /*nonce*/, salt []byte, iterations int, opts ...Option) (*EncryptorDecryptor[T], error) {
+	return NewWithPassword[T](password, salt, iterations, opts...)
 }
 
 func (e *EncryptorDecryptor[T]) Encrypt(value T) ([]byte, error) {

--- a/encryption/encryptor_decryptor_test.go
+++ b/encryption/encryptor_decryptor_test.go
@@ -291,6 +291,40 @@ func TestNewWithPassword_RejectsLowIterations(t *testing.T) {
 	}
 }
 
+func TestNew_WithAllowLegacyParameters_StillRejectsInsaneParameters(t *testing.T) {
+	// WithAllowLegacyParameters relaxes the floor — it does NOT disable the
+	// basic sanity checks that protect against meaningless PBKDF2 inputs.
+	// pbkdf2.Key does not error on non-positive iterations or empty salts;
+	// it silently produces a trivially-derived key, so callers must be stopped
+	// at construction time regardless of the opt-out.
+	cases := []struct {
+		name       string
+		salt       []byte
+		iterations int
+		wantErr    error
+	}{
+		{"zero iterations", []byte("saltyvalu2"), 0, ErrIterationsTooLow},
+		{"negative iterations", []byte("saltyvalu2"), -1, ErrIterationsTooLow},
+		{"empty salt", []byte{}, 4096, ErrSaltTooShort},
+		{"nil salt", nil, 4096, ErrSaltTooShort},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := New[string](tc.salt, tc.iterations, WithAllowLegacyParameters()); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			} else if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected %v, got: %v", tc.wantErr, err)
+			}
+
+			if _, err := NewWithPassword[string]([]byte("password"), tc.salt, tc.iterations, WithAllowLegacyParameters()); err == nil {
+				t.Fatalf("NewWithPassword: expected error for %s, got nil", tc.name)
+			} else if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("NewWithPassword: expected %v, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestNew_WithAllowLegacyParameters_BypassesValidation(t *testing.T) {
 	// Short salt (10 bytes) and iterations below MinIterations must be accepted
 	// when the opt-out option is provided, to support legacy persisted data.

--- a/encryption/encryptor_decryptor_test.go
+++ b/encryption/encryptor_decryptor_test.go
@@ -283,3 +283,75 @@ func TestNewWithPassword_RejectsLowIterations(t *testing.T) {
 		})
 	}
 }
+
+func TestNew_WithAllowLegacyParameters_BypassesValidation(t *testing.T) {
+	// Short salt (10 bytes) and iterations below MinIterations must be accepted
+	// when the opt-out option is provided, to support legacy persisted data.
+	shortSalt := []byte("saltyvalu2") // 10 bytes, below MinSaltLength=16
+	lowIterations := 4096             // below MinIterations=100_000
+
+	ed, err := New[string](shortSalt, lowIterations, WithAllowLegacyParameters())
+	if err != nil {
+		t.Fatalf("New() with WithAllowLegacyParameters returned error: %v", err)
+	}
+
+	input := "legacy roundtrip"
+	ciphertext, err := ed.Encrypt(input)
+	if err != nil {
+		t.Fatalf("Encrypt() error: %v", err)
+	}
+	decrypted, err := ed.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt() error: %v", err)
+	}
+	if decrypted != input {
+		t.Errorf("Decrypt() = %q, want %q", decrypted, input)
+	}
+}
+
+func TestNewWithPassword_WithAllowLegacyParameters_BypassesValidation(t *testing.T) {
+	shortSalt := []byte("saltyvalu2")
+	lowIterations := 4096
+
+	ed, err := NewWithPassword[string]([]byte("password"), shortSalt, lowIterations, WithAllowLegacyParameters())
+	if err != nil {
+		t.Fatalf("NewWithPassword() with WithAllowLegacyParameters returned error: %v", err)
+	}
+
+	input := "legacy roundtrip"
+	ciphertext, err := ed.Encrypt(input)
+	if err != nil {
+		t.Fatalf("Encrypt() error: %v", err)
+	}
+	decrypted, err := ed.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt() error: %v", err)
+	}
+	if decrypted != input {
+		t.Errorf("Decrypt() = %q, want %q", decrypted, input)
+	}
+}
+
+func TestNewWithPasswordNonce_WithAllowLegacyParameters_BypassesValidation(t *testing.T) {
+	// The deprecated shim must also forward the option.
+	shortSalt := []byte("saltyvalu2")
+	lowIterations := 4096
+
+	ed, err := NewWithPasswordNonce[string]([]byte("password"), []byte("ignored-nonce"), shortSalt, lowIterations, WithAllowLegacyParameters())
+	if err != nil {
+		t.Fatalf("NewWithPasswordNonce() with WithAllowLegacyParameters returned error: %v", err)
+	}
+
+	input := "legacy roundtrip"
+	ciphertext, err := ed.Encrypt(input)
+	if err != nil {
+		t.Fatalf("Encrypt() error: %v", err)
+	}
+	decrypted, err := ed.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt() error: %v", err)
+	}
+	if decrypted != input {
+		t.Errorf("Decrypt() = %q, want %q", decrypted, input)
+	}
+}

--- a/encryption/encryptor_decryptor_test.go
+++ b/encryption/encryptor_decryptor_test.go
@@ -5,9 +5,16 @@ package encryption
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
 	"errors"
 	"reflect"
 	"testing"
+
+	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/zendesk/go-generics/serialize"
 )
 
 func TestEncryptDecrypt_Bytes(t *testing.T) {
@@ -353,5 +360,255 @@ func TestNewWithPasswordNonce_WithAllowLegacyParameters_BypassesValidation(t *te
 	}
 	if decrypted != input {
 		t.Errorf("Decrypt() = %q, want %q", decrypted, input)
+	}
+}
+
+// encryptLegacyV0 faithfully reproduces the pre-#18 (2025-era) Encrypt wire format:
+// a single fixed nonce is reused for every call, and Seal is called with nil as
+// the dst so the output is just [ciphertext|tag] — no nonce prefix.
+// Key derivation matches pre-#18 NewWithPasswordNonce: pbkdf2 with the same
+// parameters that the current NewWithPassword uses.
+func encryptLegacyV0[T any](t *testing.T, password, salt, nonce []byte, iterations int, value T) []byte {
+	t.Helper()
+
+	aesKey := pbkdf2.Key(password, salt, iterations, 32, sha256.New)
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("cipher.NewGCM: %v", err)
+	}
+
+	// Exactly matches the pre-#18 Encrypt path in encryption/encryptor_decryptor.go:
+	//   w := wrapper[T]{T: value}
+	//   bytes, _ := serialize.NewSerializer[wrapper[T]]().FromDynamicType(w).ToBytes()
+	//   ciphertext := e.aesgcm.Seal(nil, e.nonce, bytes, nil)
+	w := wrapper[T]{T: value}
+	plaintext, err := serialize.NewSerializer[wrapper[T]]().FromDynamicType(w).ToBytes()
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return aesgcm.Seal(nil, nonce, plaintext, nil)
+}
+
+// TestLegacyV0_Decryptable_ByNewWithLegacyNonce is the core cross-version proof:
+// ciphertext produced by the pre-#18 wire format (fixed nonce, no prefix) must
+// roundtrip through a current EncryptorDecryptor when WithLegacyNonce is
+// supplied, and the default (no-option) constructor must fail to decrypt it.
+func TestLegacyV0_Decryptable_ByNewWithLegacyNonce(t *testing.T) {
+	password := []byte("production-password")
+	// Intentionally a 10-byte salt to mirror ssv2-api's CryptoSalt "73616C7479" —
+	// the exact reason WithAllowLegacyParameters exists.
+	salt := []byte("saltyvalu2")
+	// Intentionally 4096 iterations, the legacy default that pre-dates MinIterations.
+	iterations := 4096
+	nonce := []byte("legacy-none1") // 12 bytes — matches NonceLength
+
+	input := "secret written by old go-generics"
+	legacyCiphertext := encryptLegacyV0[string](t, password, salt, nonce, iterations, input)
+
+	// 1. A current-default encryptor must NOT be able to decrypt legacy bytes:
+	//    it will slice off the first 12 bytes as a (wrong) nonce and fail auth.
+	currentDefault, err := NewWithPassword[string](password, []byte("1234567890abcdef"), MinIterations)
+	if err != nil {
+		t.Fatalf("NewWithPassword (default) setup: %v", err)
+	}
+	if _, err := currentDefault.Decrypt(legacyCiphertext); err == nil {
+		t.Fatal("current default decrypter unexpectedly decrypted legacy ciphertext — wire format detection is broken")
+	}
+
+	// 2. A current encryptor opted in to legacy parameters AND legacy nonce MUST
+	//    be able to decrypt the legacy bytes.
+	legacyReader, err := NewWithPassword[string](
+		password, salt, iterations,
+		WithAllowLegacyParameters(),
+		WithLegacyNonce(nonce),
+	)
+	if err != nil {
+		t.Fatalf("NewWithPassword with legacy opts: %v", err)
+	}
+	decrypted, err := legacyReader.Decrypt(legacyCiphertext)
+	if err != nil {
+		t.Fatalf("legacyReader.Decrypt: %v", err)
+	}
+	if decrypted != input {
+		t.Errorf("Decrypt() = %q, want %q", decrypted, input)
+	}
+}
+
+// TestLegacyV0_Encrypt_ReadableByLegacyAlgorithm confirms the legacy-nonce path
+// produces the same wire format the old version did. We encrypt with the new
+// code + WithLegacyNonce, then decrypt by hand using the documented pre-#18
+// algorithm (Open with fixed nonce against [ciphertext|tag]). If this roundtrips
+// we've proven Encrypt is byte-compatible with the old format.
+func TestLegacyV0_Encrypt_ReadableByLegacyAlgorithm(t *testing.T) {
+	password := []byte("production-password")
+	salt := []byte("saltyvalu2")
+	iterations := 4096
+	nonce := []byte("legacy-none1")
+
+	input := "written by new encryptor in legacy mode"
+
+	ed, err := NewWithPassword[string](
+		password, salt, iterations,
+		WithAllowLegacyParameters(),
+		WithLegacyNonce(nonce),
+	)
+	if err != nil {
+		t.Fatalf("NewWithPassword with legacy opts: %v", err)
+	}
+	ciphertext, err := ed.Encrypt(input)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Hand-rolled pre-#18 Decrypt: no nonce prefix, fixed nonce, plain Open.
+	aesKey := pbkdf2.Key(password, salt, iterations, 32, sha256.New)
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("cipher.NewGCM: %v", err)
+	}
+	plaintext, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		t.Fatalf("legacy-style Open: %v", err)
+	}
+
+	w := wrapper[string]{}
+	result, err := serialize.NewSerializer[wrapper[string]]().FromBytes(plaintext).ToDynamicType(serialize.Reflect, w)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	got, ok := result.(wrapper[string])
+	if !ok {
+		t.Fatalf("result is %T, not wrapper[string]", result)
+	}
+	if got.T != input {
+		t.Errorf("roundtrip = %q, want %q", got.T, input)
+	}
+}
+
+// TestLegacyV0_Roundtrip_WithinCurrent is the pragmatic "ssv2-api" check: the
+// current encryptor, opted in to legacy mode, roundtrips its own output. This
+// is what the service will actually do in production (write + read legacy rows).
+func TestLegacyV0_Roundtrip_WithinCurrent(t *testing.T) {
+	salt := []byte("saltyvalu2")
+	iterations := 4096
+	nonce := []byte("legacy-none1")
+
+	ed, err := NewWithPassword[string](
+		[]byte("production-password"), salt, iterations,
+		WithAllowLegacyParameters(),
+		WithLegacyNonce(nonce),
+	)
+	if err != nil {
+		t.Fatalf("NewWithPassword: %v", err)
+	}
+
+	for _, input := range []string{"", "short", "a much longer secret value that is also encrypted"} {
+		ct, err := ed.Encrypt(input)
+		if err != nil {
+			t.Fatalf("Encrypt(%q): %v", input, err)
+		}
+		// Fixed-nonce Seal does not prefix a nonce: no [nonce|...] framing.
+		// We cannot test the exact length cheaply here (serializer adds overhead),
+		// but we can assert we did NOT accidentally double up by checking that
+		// our own Decrypt on the output succeeds.
+		got, err := ed.Decrypt(ct)
+		if err != nil {
+			t.Fatalf("Decrypt(%q): %v", input, err)
+		}
+		if got != input {
+			t.Errorf("roundtrip: got %q, want %q", got, input)
+		}
+	}
+}
+
+// TestLegacyNonce_RejectsWrongLength protects callers from silently producing
+// garbage ciphertext when they pass a non-12-byte nonce.
+func TestLegacyNonce_RejectsWrongLength(t *testing.T) {
+	tests := []struct {
+		name  string
+		nonce []byte
+	}{
+		{"empty", []byte{}},
+		{"too short", []byte("short")},
+		{"too long", []byte("way too long to be a GCM nonce")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewWithPassword[string](
+				[]byte("password"), []byte("1234567890abcdef"), MinIterations,
+				WithLegacyNonce(tt.nonce),
+			)
+			if err == nil {
+				t.Fatal("expected ErrInvalidNonce, got nil")
+			}
+			if !errors.Is(err, ErrInvalidNonce) {
+				t.Fatalf("expected ErrInvalidNonce, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestCurrent_vs_Legacy_WireFormats_Differ is a guard: if someone ever makes
+// Encrypt emit the legacy format by default, this test will fail. It confirms
+// that in the default (no WithLegacyNonce) path, ciphertext starts with the
+// randomly generated nonce — i.e. the wire formats are genuinely distinct.
+func TestCurrent_vs_Legacy_WireFormats_Differ(t *testing.T) {
+	password := []byte("password")
+	salt := []byte("1234567890abcdef")
+	nonce := []byte("legacy-none1")
+
+	current, err := NewWithPassword[string](password, salt, MinIterations)
+	if err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	legacy, err := NewWithPassword[string](
+		password, salt, MinIterations,
+		WithLegacyNonce(nonce),
+	)
+	if err != nil {
+		t.Fatalf("legacy: %v", err)
+	}
+
+	currentCT, err := current.Encrypt("hello")
+	if err != nil {
+		t.Fatalf("current.Encrypt: %v", err)
+	}
+	legacyCT, err := legacy.Encrypt("hello")
+	if err != nil {
+		t.Fatalf("legacy.Encrypt: %v", err)
+	}
+
+	// Current must be exactly NonceLength bytes longer than legacy for the same
+	// plaintext, because it prepends a fresh nonce and uses the same AEAD tag.
+	if len(currentCT)-len(legacyCT) != NonceLength {
+		t.Errorf("expected current ciphertext to be %d bytes longer than legacy, got current=%d legacy=%d",
+			NonceLength, len(currentCT), len(legacyCT))
+	}
+
+	// Current must NOT decrypt legacy bytes, and vice-versa.
+	if _, err := current.Decrypt(legacyCT); err == nil {
+		t.Error("current.Decrypt unexpectedly accepted legacy ciphertext")
+	}
+	if _, err := legacy.Decrypt(currentCT); err == nil {
+		t.Error("legacy.Decrypt unexpectedly accepted current ciphertext")
+	}
+
+	// Legacy ciphertexts for identical plaintext must be byte-identical (fixed
+	// nonce reuse) — this is the documented, insecure property of legacy mode,
+	// and proves the nonce is actually fixed.
+	legacyCT2, err := legacy.Encrypt("hello")
+	if err != nil {
+		t.Fatalf("legacy.Encrypt (2): %v", err)
+	}
+	if !bytes.Equal(legacyCT, legacyCT2) {
+		t.Error("legacy encryptor produced different ciphertexts for the same plaintext — fixed nonce is not actually fixed")
 	}
 }

--- a/encryption/option.go
+++ b/encryption/option.go
@@ -1,0 +1,29 @@
+package encryption
+
+// Option configures an EncryptorDecryptor constructor.
+type Option func(*options)
+
+type options struct {
+	allowLegacyParameters bool
+}
+
+func resolveOptions(opts ...Option) options {
+	var cfg options
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// WithAllowLegacyParameters disables validation of the minimum salt length
+// (MinSaltLength) and minimum iteration count (MinIterations).
+//
+// Use only when an existing production system relies on an already-persisted
+// salt or iteration count that pre-dates the current minimums, and rotating
+// them requires a coordinated data re-encryption that cannot ship with the
+// upgrade. New deployments must not use this option.
+func WithAllowLegacyParameters() Option {
+	return func(o *options) {
+		o.allowLegacyParameters = true
+	}
+}

--- a/encryption/option.go
+++ b/encryption/option.go
@@ -5,6 +5,7 @@ type Option func(*options)
 
 type options struct {
 	allowLegacyParameters bool
+	legacyNonce           []byte
 }
 
 func resolveOptions(opts ...Option) options {
@@ -25,5 +26,27 @@ func resolveOptions(opts ...Option) options {
 func WithAllowLegacyParameters() Option {
 	return func(o *options) {
 		o.allowLegacyParameters = true
+	}
+}
+
+// WithLegacyNonce selects the pre-2026-03 ciphertext wire format: the nonce is
+// fixed at construction time (the one provided here) and is NOT prepended to
+// ciphertext. Both Encrypt and Decrypt use the supplied nonce directly.
+//
+// NOT RECOMMENDED. This exists purely for backwards compatibility with data
+// that was encrypted by an older go-generics release (pre-#18), which stored
+// ciphertext as [ciphertext|tag] without a nonce prefix. New callers, and any
+// caller that can migrate its persisted data, must not use this option — AES-GCM
+// is catastrophically broken under nonce reuse (confidentiality AND authenticity
+// fail), so a fixed-nonce encryptor should be treated as read-only whenever
+// possible. Encrypting many messages under a single key+nonce with this option
+// enabled is a security bug; prefer decrypting legacy rows with this option and
+// re-encrypting them using a default (per-call random nonce) encryptor.
+//
+// The nonce must be exactly NonceLength (12) bytes. Passing a different length
+// causes the constructor to return ErrInvalidNonce.
+func WithLegacyNonce(nonce []byte) Option {
+	return func(o *options) {
+		o.legacyNonce = nonce
 	}
 }


### PR DESCRIPTION
## Summary

Two new `encryption.Option` values for callers stuck on legacy persisted data:

- **`WithAllowLegacyParameters()`** — bypasses `MinSaltLength` (16 byte) and `MinIterations` (100 000) validation in `New`, `NewWithPassword`, and `NewWithPasswordNonce`. Also forwardable into `EncryptedCache` via a new `cache.WithEncryptionOptions(...)` `CacheBackendOption`.
- **`WithLegacyNonce(nonce)`** — restores the pre-#18 ciphertext wire format (fixed struct-level nonce, no nonce prefix). **Not recommended.** Reintroduces the exact AES-GCM nonce-reuse condition #18 fixed, so it should be used to *read* legacy rows and re-encrypt them with a default encryptor — not to write new data.

## Why both are needed

#15 and #17 added `MinSaltLength` / `MinIterations` validation. #18 additionally changed the ciphertext wire format from `[ciphertext|tag]` (fixed struct nonce) to `[nonce|ciphertext|tag]` (per-call random nonce).

For a caller that persists encrypted data (e.g. secret-service-v2-api), that second change is the bigger blocker: the stored bytes were produced with the old format, so a default current `Decrypt` will treat the first 12 bytes as a (wrong) nonce and fail authentication. `WithAllowLegacyParameters` alone is insufficient — the key derivation is identical between versions (same `pbkdf2.Key(password, salt, iterations, 32, sha256.New)`), but the framing isn't.

`WithLegacyNonce` covers that gap so services can bump go-generics, pick up the Redis ACL / nonce-reuse / salt-validation fixes, and plan an asynchronous migration to the new wire format.

## Cross-version compatibility proof

Three tests in `encryption/encryptor_decryptor_test.go` pin the behavior:

- `TestLegacyV0_Decryptable_ByNewWithLegacyNonce` hand-rolls a pre-#18 encrypt (pbkdf2 → `aesgcm.Seal(nil, nonce, bytes, nil)`) and then decrypts with the current `NewWithPassword` + `WithLegacyNonce`. Also asserts the **default** decrypter rejects legacy bytes (so there's no silent corruption risk).
- `TestLegacyV0_Encrypt_ReadableByLegacyAlgorithm` encrypts with the new code in legacy mode, then decrypts with the hand-rolled pre-#18 `aesgcm.Open(nil, nonce, ct, nil)`. Byte-level wire-format compatibility in both directions.
- `TestCurrent_vs_Legacy_WireFormats_Differ` asserts:
  - current ciphertext is exactly `NonceLength` (12) bytes longer than legacy for the same plaintext
  - current ↔ legacy encryptors cannot cross-decrypt each other's output
  - legacy mode genuinely fixes the nonce (same plaintext → byte-identical ciphertext)

Plus `TestLegacyNonce_RejectsWrongLength` (empty / too short / too long → `ErrInvalidNonce`) and the three `WithAllowLegacyParameters` bypass tests (`New` / `NewWithPassword` / `NewWithPasswordNonce`) and two cache-layer tests (`TestNewEncryptedCache_WithEncryptionOptions_AllowsLegacyParameters`, `TestNewEncryptedCacheWithPassword_WithEncryptionOptions_AllowsLegacyParameters`).

## Test plan
- [x] `go build ./...`
- [x] `go vet -tags test ./...`
- [x] `go test -tags test ./... -count=1` — all packages pass
- [x] All existing validation-error tests still pass (default behavior unchanged when no options supplied).