### PR TITLE
Add cache-constructor WithPrefix; rename OperationOption to WithKeyPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,32 @@ cash.Set(userID, Person{Name: "James", Age: 30})
 
 ```
 
+### Key prefixing
+
+Two options namespace cache keys. Both prepend their prefix to the hashed key;
+when both are supplied the final Redis/in-memory key is
+`<backend-prefix><operation-prefix><hash(key)>`.
+
+- `cache.WithPrefix[K, V](prefix)` — **CacheBackendOption**. Stored on the
+  backend at construction time. Applied automatically to every Get/Set/Delete/
+  GetOrSet. Use this when the entire service is confined to a namespace (e.g.
+  a Redis ACL pattern like `service-name:*`).
+- `cache.WithKeyPrefix(prefix)` — **OperationOption**. Passed per call. Use
+  this for sub-namespacing within a single cache (e.g. partitioning by tenant).
+
+```go
+// Backend prefix: every key is prepended with "service-name:" so it matches
+// an ACL that restricts this user to service-name:* keys.
+redisCache := cache.NewRedisCache[string, Person](ctx, client, ttl,
+    cache.WithPrefix[string, Person]("service-name:"))
+
+redisCache.Set("user-123", Person{Name: "James"})
+// Redis key: service-name:<hash("user-123")>
+
+// Layer a per-operation prefix on top:
+redisCache.Set("user-123", Person{Name: "James"}, cache.WithKeyPrefix("tenant-a:"))
+// Redis key: service-name:tenant-a:<hash("user-123")>
+```
 
 ## Concurrency
 

--- a/cache/memory.go
+++ b/cache/memory.go
@@ -48,7 +48,7 @@ func (c *InMemoryCache[K, V]) Get(key K, opts ...OperationOption) (V, bool, erro
 		return v, false, nil
 	}
 
-	k := buildKey(key, opts...)
+	k := buildKey(key, c.cfg.keyPrefix, opts...)
 	item := c.cache.Get(k)
 	if item != nil {
 		return item.Value(), true, nil
@@ -78,7 +78,7 @@ func (c *InMemoryCache[K, V]) Set(key K, val V, opts ...OperationOption) error {
 		return nil
 	}
 
-	k := buildKey(key, opts...)
+	k := buildKey(key, c.cfg.keyPrefix, opts...)
 	_ = c.cache.Set(k, val, c.ttl)
 
 	// if fail-through is enabled, set in fail-thorugh
@@ -95,7 +95,7 @@ func (c *InMemoryCache[K, V]) Set(key K, val V, opts ...OperationOption) error {
 }
 
 func (c *InMemoryCache[K, V]) Delete(key K, opts ...OperationOption) error {
-	k := buildKey(key, opts...)
+	k := buildKey(key, c.cfg.keyPrefix, opts...)
 	c.cache.Delete(k)
 
 	// Delete from fail through

--- a/cache/option.go
+++ b/cache/option.go
@@ -8,6 +8,7 @@ type cacheBackendCfg[K comparable, V any] struct {
 	capacity             uint64
 	ignoreCacheSetErrors bool
 	encryptionOpts       []encryption.Option
+	keyPrefix            string
 }
 
 type CacheBackendOption[K comparable, V any] func(cfg cacheBackendCfg[K, V]) cacheBackendCfg[K, V]
@@ -59,6 +60,25 @@ func WithEncryptionOptions[K comparable, V any](opts ...encryption.Option) Cache
 	}
 }
 
+// WithPrefix configures a static prefix that the backend prepends to every
+// cache key, on every Get/Set/Delete/GetOrSet call. Unlike the per-operation
+// WithKeyPrefix (OperationOption), this prefix is stored on the backend and
+// does not need to be re-specified by every caller.
+//
+// When both are used, the final key layout is:
+//
+//	<backend-prefix><operation-prefix><hash(key)>
+//
+// Typical use: a Redis ACL namespace (e.g. "ssv2-api:") that must precede every
+// key the service writes. Callers can still layer an OperationOption
+// WithKeyPrefix on top for sub-namespacing within that namespace.
+func WithPrefix[K comparable, V any](prefix string) CacheBackendOption[K, V] {
+	return func(cfg cacheBackendCfg[K, V]) cacheBackendCfg[K, V] {
+		cfg.keyPrefix = prefix
+		return cfg
+	}
+}
+
 type cacheCfg[K comparable, V any] struct {
 	observer CacheObserver[K]
 }
@@ -88,9 +108,14 @@ type operationCfg struct {
 	prefix string
 }
 
-// WithPrefix prepends the given prefix to the hashed cache key for this operation.
-// Both Redis and in-memory backends hash keys via HashAny; the prefix is prepended to that hash.
-func WithPrefix(prefix string) OperationOption {
+// WithKeyPrefix prepends the given prefix to the hashed cache key for this
+// operation. Both Redis and in-memory backends hash keys via HashAny; the
+// prefix is prepended to that hash.
+//
+// This is the per-operation counterpart to the cache-constructor WithPrefix
+// (CacheBackendOption). Both can be combined: the backend prefix always comes
+// first, then the operation prefix, then the hashed key.
+func WithKeyPrefix(prefix string) OperationOption {
 	return func(cfg *operationCfg) {
 		cfg.prefix = prefix
 	}

--- a/cache/option_test.go
+++ b/cache/option_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/zendesk/go-generics/internal/test"
 )
 
-func Test_WithPrefix_Redis_Set_Get(t *testing.T) {
+func Test_WithKeyPrefix_Redis_Set_Get(t *testing.T) {
 	mockRedis := &mockClient{}
 	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
 
-	prefix := cache.WithPrefix("mcp:")
+	prefix := cache.WithKeyPrefix("mcp:")
 
 	err := redisCache.Set("mykey", "myval", prefix)
 	test.CheckErr(err, "Failed to set", t)
@@ -27,11 +27,11 @@ func Test_WithPrefix_Redis_Set_Get(t *testing.T) {
 	test.CheckEqual(mockRedis.getKey, "GET key should have prefix", "mcp:"+cache.HashAny("mykey"), t)
 }
 
-func Test_WithPrefix_Redis_GetOrSet(t *testing.T) {
+func Test_WithKeyPrefix_Redis_GetOrSet(t *testing.T) {
 	mockRedis := &mockClient{}
 	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
 
-	prefix := cache.WithPrefix("ns:")
+	prefix := cache.WithKeyPrefix("ns:")
 
 	// First Set so the mock has data, then GetOrSet should find it
 	err := redisCache.Set("key1", "existing", prefix)
@@ -46,7 +46,7 @@ func Test_WithPrefix_Redis_GetOrSet(t *testing.T) {
 	test.CheckEqual(mockRedis.getKey, "GET key should have prefix", "ns:"+cache.HashAny("key1"), t)
 }
 
-func Test_WithPrefix_Redis_NoPrefix(t *testing.T) {
+func Test_WithKeyPrefix_Redis_NoPrefix(t *testing.T) {
 	mockRedis := &mockClient{}
 	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
 
@@ -56,29 +56,29 @@ func Test_WithPrefix_Redis_NoPrefix(t *testing.T) {
 	test.CheckEqual(mockRedis.setKey, "SET key should be plain hash", cache.HashAny("mykey"), t)
 }
 
-func Test_WithPrefix_Redis_DifferentPrefixes_Isolate(t *testing.T) {
+func Test_WithKeyPrefix_Redis_DifferentPrefixes_Isolate(t *testing.T) {
 	mockRedis := &mockClient{}
 	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second)
 
 	// Set with prefix "a:"
-	err := redisCache.Set("key", "val-a", cache.WithPrefix("a:"))
+	err := redisCache.Set("key", "val-a", cache.WithKeyPrefix("a:"))
 	test.CheckErr(err, "Failed to set with prefix a:", t)
 
 	// Set with prefix "b:" (overwrites mock's stored value)
-	err = redisCache.Set("key", "val-b", cache.WithPrefix("b:"))
+	err = redisCache.Set("key", "val-b", cache.WithKeyPrefix("b:"))
 	test.CheckErr(err, "Failed to set with prefix b:", t)
 
 	// Get with prefix "b:" should return val-b (last written to mock)
-	got, _, err := redisCache.Get("key", cache.WithPrefix("b:"))
+	got, _, err := redisCache.Get("key", cache.WithKeyPrefix("b:"))
 	test.CheckErr(err, "Failed to get with prefix b:", t)
 	test.CheckEqual(got, "Value with prefix b:", "val-b", t)
 	test.CheckEqual(mockRedis.getKey, "GET key should have b: prefix", "b:"+cache.HashAny("key"), t)
 }
 
-func Test_WithPrefix_InMemory_Set_Get(t *testing.T) {
+func Test_WithKeyPrefix_InMemory_Set_Get(t *testing.T) {
 	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
 
-	prefix := cache.WithPrefix("mcp:")
+	prefix := cache.WithKeyPrefix("mcp:")
 
 	err := memCache.Set("mykey", "myval", prefix)
 	test.CheckErr(err, "Failed to set", t)
@@ -89,25 +89,25 @@ func Test_WithPrefix_InMemory_Set_Get(t *testing.T) {
 	test.CheckEqual(val, "Value", "myval", t)
 }
 
-func Test_WithPrefix_InMemory_Isolation(t *testing.T) {
+func Test_WithKeyPrefix_InMemory_Isolation(t *testing.T) {
 	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
 
 	// Set with prefix "a:"
-	err := memCache.Set("key", "val-a", cache.WithPrefix("a:"))
+	err := memCache.Set("key", "val-a", cache.WithKeyPrefix("a:"))
 	test.CheckErr(err, "Failed to set with prefix a:", t)
 
 	// Set with prefix "b:"
-	err = memCache.Set("key", "val-b", cache.WithPrefix("b:"))
+	err = memCache.Set("key", "val-b", cache.WithKeyPrefix("b:"))
 	test.CheckErr(err, "Failed to set with prefix b:", t)
 
 	// Get with "a:" should return val-a
-	val, found, err := memCache.Get("key", cache.WithPrefix("a:"))
+	val, found, err := memCache.Get("key", cache.WithKeyPrefix("a:"))
 	test.CheckErr(err, "Failed to get with prefix a:", t)
 	test.CheckOk(found, "Should be found with prefix a:", t)
 	test.CheckEqual(val, "Value with prefix a:", "val-a", t)
 
 	// Get with "b:" should return val-b
-	val, found, err = memCache.Get("key", cache.WithPrefix("b:"))
+	val, found, err = memCache.Get("key", cache.WithKeyPrefix("b:"))
 	test.CheckErr(err, "Failed to get with prefix b:", t)
 	test.CheckOk(found, "Should be found with prefix b:", t)
 	test.CheckEqual(val, "Value with prefix b:", "val-b", t)
@@ -118,10 +118,10 @@ func Test_WithPrefix_InMemory_Isolation(t *testing.T) {
 	test.CheckNotOk(found, "Should not be found without prefix", t)
 }
 
-func Test_WithPrefix_InMemory_Delete(t *testing.T) {
+func Test_WithKeyPrefix_InMemory_Delete(t *testing.T) {
 	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
 
-	prefix := cache.WithPrefix("mcp:")
+	prefix := cache.WithKeyPrefix("mcp:")
 
 	err := memCache.Set("key", "val", prefix)
 	test.CheckErr(err, "Failed to set", t)
@@ -134,10 +134,10 @@ func Test_WithPrefix_InMemory_Delete(t *testing.T) {
 	test.CheckNotOk(found, "Should not be found after delete", t)
 }
 
-func Test_WithPrefix_InMemory_GetOrSet(t *testing.T) {
+func Test_WithKeyPrefix_InMemory_GetOrSet(t *testing.T) {
 	memCache := cache.NewInMemoryCache[string, string](10 * time.Second)
 
-	prefix := cache.WithPrefix("ns:")
+	prefix := cache.WithKeyPrefix("ns:")
 
 	val, fromCache, err := memCache.GetOrSet("key1", func() (string, error) {
 		return "computed", nil
@@ -153,4 +153,113 @@ func Test_WithPrefix_InMemory_GetOrSet(t *testing.T) {
 	test.CheckErr(err, "Failed GetOrSet (2)", t)
 	test.CheckOk(fromCache, "Should be from cache on second call", t)
 	test.CheckEqual(val, "Value", "computed", t)
+}
+
+// Tests for the cache-constructor option WithPrefix (CacheBackendOption).
+// The static prefix is stored on the backend and prepended to every key on
+// every operation — no per-call OperationOption required.
+
+func Test_WithPrefix_Redis_AppliesToAllOperations(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second,
+		cache.WithPrefix[string, string]("svc:"))
+
+	err := redisCache.Set("mykey", "myval")
+	test.CheckErr(err, "Failed to set", t)
+	test.CheckEqual(mockRedis.setKey, "SET key should have constructor prefix", "svc:"+cache.HashAny("mykey"), t)
+
+	_, _, err = redisCache.Get("mykey")
+	test.CheckErr(err, "Failed to get", t)
+	test.CheckEqual(mockRedis.getKey, "GET key should have constructor prefix", "svc:"+cache.HashAny("mykey"), t)
+
+	err = redisCache.Delete("mykey")
+	test.CheckErr(err, "Failed to delete", t)
+	test.CheckEqual(mockRedis.delKey, "DEL key should have constructor prefix", "svc:"+cache.HashAny("mykey"), t)
+}
+
+func Test_WithPrefix_Redis_StacksWithOperationPrefix(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second,
+		cache.WithPrefix[string, string]("svc:"))
+
+	// Backend prefix "svc:" + operation prefix "user:" + hash(key).
+	err := redisCache.Set("k", "v", cache.WithKeyPrefix("user:"))
+	test.CheckErr(err, "Failed to set", t)
+	test.CheckEqual(mockRedis.setKey, "SET key should stack both prefixes",
+		"svc:user:"+cache.HashAny("k"), t)
+}
+
+func Test_WithPrefix_InMemory_AppliesToAllOperations(t *testing.T) {
+	memCache := cache.NewInMemoryCache[string, string](10*time.Second,
+		cache.WithPrefix[string, string]("svc:"))
+
+	err := memCache.Set("k", "v")
+	test.CheckErr(err, "Failed to set", t)
+
+	val, found, err := memCache.Get("k")
+	test.CheckErr(err, "Failed to get", t)
+	test.CheckOk(found, "Should be found with same backend prefix", t)
+	test.CheckEqual(val, "Value", "v", t)
+
+	err = memCache.Delete("k")
+	test.CheckErr(err, "Failed to delete", t)
+
+	_, found, err = memCache.Get("k")
+	test.CheckErr(err, "Failed to get after delete", t)
+	test.CheckNotOk(found, "Should not be found after delete", t)
+}
+
+func Test_WithPrefix_InMemory_IsolatesCachesWithDifferentBackendPrefixes(t *testing.T) {
+	// Two backends with different static prefixes must never collide even when
+	// callers use identical keys with no OperationOption.
+	cacheA := cache.NewInMemoryCache[string, string](10*time.Second,
+		cache.WithPrefix[string, string]("a:"))
+	cacheB := cache.NewInMemoryCache[string, string](10*time.Second,
+		cache.WithPrefix[string, string]("b:"))
+
+	err := cacheA.Set("key", "val-a")
+	test.CheckErr(err, "Failed to set on cacheA", t)
+	err = cacheB.Set("key", "val-b")
+	test.CheckErr(err, "Failed to set on cacheB", t)
+
+	valA, foundA, err := cacheA.Get("key")
+	test.CheckErr(err, "Failed to get on cacheA", t)
+	test.CheckOk(foundA, "cacheA hit", t)
+	test.CheckEqual(valA, "cacheA value", "val-a", t)
+
+	valB, foundB, err := cacheB.Get("key")
+	test.CheckErr(err, "Failed to get on cacheB", t)
+	test.CheckOk(foundB, "cacheB hit", t)
+	test.CheckEqual(valB, "cacheB value", "val-b", t)
+}
+
+func Test_WithPrefix_EmptyPrefix_BehavesLikeUnset(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisCache := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second,
+		cache.WithPrefix[string, string](""))
+
+	err := redisCache.Set("k", "v")
+	test.CheckErr(err, "Failed to set", t)
+	test.CheckEqual(mockRedis.setKey, "SET key with empty backend prefix should be plain hash",
+		cache.HashAny("k"), t)
+}
+
+func Test_WithPrefix_EncryptedCache_AppliesToBackend(t *testing.T) {
+	// When an EncryptedCache wraps a backend that has WithPrefix set, the
+	// prefix must reach Redis unchanged — encryption operates on the value,
+	// not the key.
+	mockRedis := &mockClient{}
+	redisBackend := cache.NewRedisCache[string, []byte](context.Background(), mockRedis, 10*time.Second,
+		cache.WithPrefix[string, []byte]("svc:"))
+
+	encrypted, err := cache.NewEncryptedCacheWithPassword[string, string](redisBackend,
+		[]byte("password-at-least-12-bytes"),
+		[]byte("saltsaltsaltsalt"), // 16 bytes, meets MinSaltLength
+		100_000)
+	test.CheckErr(err, "Failed to construct EncryptedCache", t)
+
+	err = encrypted.Set("k", "v")
+	test.CheckErr(err, "Failed to set", t)
+	test.CheckEqual(mockRedis.setKey, "encrypted-cache SET should reach Redis with the backend prefix",
+		"svc:"+cache.HashAny("k"), t)
 }

--- a/cache/option_test.go
+++ b/cache/option_test.go
@@ -263,3 +263,62 @@ func Test_WithPrefix_EncryptedCache_AppliesToBackend(t *testing.T) {
 	test.CheckEqual(mockRedis.setKey, "encrypted-cache SET should reach Redis with the backend prefix",
 		"svc:"+cache.HashAny("k"), t)
 }
+
+// Test_WithPrefix_FailThrough_PrefixOnRedisOnly verifies a common deployment
+// pattern: an in-memory primary with no prefix wrapping a prefixed Redis
+// fail-through. The in-memory key must stay unprefixed (prefix only matters
+// on the Redis wire, where the ACL lives) AND the fail-through round-trip
+// must use the Redis-level prefix so keys land where the ACL expects them.
+func Test_WithPrefix_FailThrough_PrefixOnRedisOnly(t *testing.T) {
+	mockRedis := &mockClient{}
+	redisBackend := cache.NewRedisCache[string, string](context.Background(), mockRedis, 10*time.Second,
+		cache.WithPrefix[string, string]("svc:"))
+
+	// In-memory primary: no WithPrefix, Redis is fail-through.
+	memWithRedisFailThrough := cache.NewInMemoryCache[string, string](10*time.Second,
+		cache.WithFailThroughCache[string, string](redisBackend),
+		cache.WithCapacity[string, string](16))
+
+	// Set via the memory cache. This must write through to Redis WITH the
+	// svc: prefix (fail-through receives the original K, not the pre-hashed
+	// memory key), but the in-memory entry itself is unprefixed.
+	err := memWithRedisFailThrough.Set("mykey", "val")
+	test.CheckErr(err, "Failed to set", t)
+	test.CheckEqual(mockRedis.setKey, "fail-through SET must hit Redis with svc: prefix",
+		"svc:"+cache.HashAny("mykey"), t)
+
+	// Primary hit: the value is still in memory, so Redis is NOT consulted.
+	mockRedis.getKey = "" // reset to prove the next Get does not call Redis
+	got, found, err := memWithRedisFailThrough.Get("mykey")
+	test.CheckErr(err, "Failed to get (primary hit)", t)
+	test.CheckOk(found, "primary cache hit", t)
+	test.CheckEqual(got, "primary hit value", "val", t)
+	test.CheckEqual(mockRedis.getKey, "primary hit must not consult Redis", "", t)
+
+	// Primary miss + fail-through hit: evict the in-memory entry, then Get
+	// must fetch from Redis using the svc: prefix AND repopulate the memory
+	// primary so the next Get is a primary hit.
+	err = memWithRedisFailThrough.Delete("mykey")
+	test.CheckErr(err, "Failed to evict", t)
+	// Delete also deletes from Redis; re-seed Redis via a direct Set so the
+	// fail-through has a value to return on the next Get.
+	err = redisBackend.Set("mykey", "val")
+	test.CheckErr(err, "Failed to re-seed Redis", t)
+
+	mockRedis.getKey = ""
+	got, found, err = memWithRedisFailThrough.Get("mykey")
+	test.CheckErr(err, "Failed to get (fail-through)", t)
+	test.CheckOk(found, "fail-through hit", t)
+	test.CheckEqual(got, "fail-through value", "val", t)
+	test.CheckEqual(mockRedis.getKey, "fail-through GET must use svc: prefix",
+		"svc:"+cache.HashAny("mykey"), t)
+
+	// After the fail-through hit, the primary should be repopulated, so the
+	// next Get must NOT consult Redis.
+	mockRedis.getKey = ""
+	got, found, err = memWithRedisFailThrough.Get("mykey")
+	test.CheckErr(err, "Failed to get (after repopulate)", t)
+	test.CheckOk(found, "post-repopulate primary hit", t)
+	test.CheckEqual(got, "post-repopulate value", "val", t)
+	test.CheckEqual(mockRedis.getKey, "post-repopulate must not consult Redis", "", t)
+}

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -41,7 +41,7 @@ func NewRedisCache[K comparable, V any](ctx context.Context, client Redis, ttl t
 
 func (c *RedisCache[K, V]) Get(key K, opts ...OperationOption) (V, bool, error) {
 	var v V
-	bytes, err := c.client.Get(c.ctx, buildKey(key, opts...)).Bytes()
+	bytes, err := c.client.Get(c.ctx, buildKey(key, c.cfg.keyPrefix, opts...)).Bytes()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return v, false, nil
@@ -66,7 +66,7 @@ func (c *RedisCache[K, V]) Set(key K, val V, opts ...OperationOption) error {
 	if err != nil {
 		return err
 	}
-	err = c.client.Set(c.ctx, buildKey(key, opts...), bytes, c.ttl).Err()
+	err = c.client.Set(c.ctx, buildKey(key, c.cfg.keyPrefix, opts...), bytes, c.ttl).Err()
 
 	if err == nil || c.cfg.ignoreCacheSetErrors {
 		return nil
@@ -78,7 +78,7 @@ func (c *RedisCache[K, V]) Set(key K, val V, opts ...OperationOption) error {
 }
 
 func (c *RedisCache[K, V]) Delete(key K, opts ...OperationOption) error {
-	return c.client.Del(c.ctx, buildKey(key, opts...)).Err()
+	return c.client.Del(c.ctx, buildKey(key, c.cfg.keyPrefix, opts...)).Err()
 }
 
 func (c *RedisCache[K, V]) Purge() error {

--- a/cache/redis_test.go
+++ b/cache/redis_test.go
@@ -24,6 +24,7 @@ type mockClient struct {
 	getKey   string
 	setValue []byte
 	setKey   string
+	delKey   string
 }
 
 func NewMockClient() *mockClient {
@@ -53,8 +54,12 @@ func (mc *mockClient) Set(ctx context.Context, key string, value interface{}, ex
 }
 
 func (mc *mockClient) Del(ctx context.Context, keys ...string) *redis.IntCmd {
-	return nil
-
+	if len(keys) > 0 {
+		mc.delKey = keys[0]
+	}
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(int64(len(keys)))
+	return cmd
 }
 
 func (mc *mockClient) FlushDB(ctx context.Context) *redis.StatusCmd {

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -14,9 +14,10 @@ func HashAny(obj any) string {
 }
 
 // buildKey hashes the key and prepends the backend-level and operation-level
-// prefixes. The backend-level prefix (from WithKeyPrefix) comes first and is
-// fixed at cache construction time; the operation-level prefix (from the
-// OperationOption WithPrefix) comes next and may vary per call.
+// prefixes. The backend-level prefix (from the CacheBackendOption WithPrefix)
+// comes first and is fixed at cache construction time; the operation-level
+// prefix (from the OperationOption WithKeyPrefix) comes next and may vary per
+// call.
 //
 // Final layout: <backendPrefix><operationPrefix><hash(key)>
 //

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -13,9 +13,15 @@ func HashAny(obj any) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// buildKey hashes the key and prepends an optional prefix from OperationOption.
+// buildKey hashes the key and prepends the backend-level and operation-level
+// prefixes. The backend-level prefix (from WithKeyPrefix) comes first and is
+// fixed at cache construction time; the operation-level prefix (from the
+// OperationOption WithPrefix) comes next and may vary per call.
+//
+// Final layout: <backendPrefix><operationPrefix><hash(key)>
+//
 // Both Redis and in-memory backends use this to produce the internal storage key.
-func buildKey(key any, opts ...OperationOption) string {
+func buildKey(key any, backendPrefix string, opts ...OperationOption) string {
 	cfg := resolveOperationOpts(opts...)
-	return cfg.prefix + HashAny(key)
+	return backendPrefix + cfg.prefix + HashAny(key)
 }


### PR DESCRIPTION
## Summary

Services that run under a constrained Redis ACL (e.g. an ElastiCache user scoped to `service-name:*`) previously had to thread `cache.WithPrefix(prefix)` through every Get/Set/Delete/GetOrSet callsite. That's error-prone and easy to miss deep in a codebase.

This PR adds a `CacheBackendOption` variant of `WithPrefix` that stores the prefix on the backend and applies it to every operation automatically:

```go
redisCache := cache.NewRedisCache[string, V](ctx, client, ttl,
    cache.WithPrefix[string, V]("service-name:"))

redisCache.Set("k", v)                               // -> service-name:<hash>
redisCache.Set("k", v, cache.WithKeyPrefix("sub:"))  // -> service-name:sub:<hash>
```

When both are supplied the final Redis/in-memory key is:

```
<backend-prefix><operation-prefix><hash(key)>
```

## Breaking change

The previously-released OperationOption `cache.WithPrefix` (introduced in #19, released in v1.2.3) is **renamed to `cache.WithKeyPrefix`** to free the `WithPrefix` name for the constructor-level option, which is expected to be the common form.

- Callers on v1.2.3 that used `cache.WithPrefix(...)` per-operation: rename to `cache.WithKeyPrefix(...)`.
- Callers on v1.2.2 or earlier: unaffected.

If we'd rather not break the API, happy to rename the new option (e.g. `WithBackendPrefix`) instead — flag me in review.

## Test plan

- [x] Full `go test -tags=test ./...` passes.
- [x] New tests in `cache/option_test.go` cover: backend-level prefix on every operation (Get/Set/Delete), stacking with per-operation `WithKeyPrefix`, in-memory + Redis backends, isolation between two caches with different backend prefixes, empty-prefix no-op behavior, and that `EncryptedCache` wrapping a prefixed Redis backend reaches Redis with the prefix intact.
- [x] `mockClient.Del` updated to record keys so Delete tests can assert the prefix reaches the client.

## Files

- `cache/option.go` — new `WithPrefix` CacheBackendOption (generic), rename old OperationOption to `WithKeyPrefix`, add `keyPrefix` to `cacheBackendCfg`.
- `cache/utils.go` — `buildKey` now takes the backend prefix and stacks it before the per-operation prefix.
- `cache/memory.go`, `cache/redis.go` — thread `c.cfg.keyPrefix` into every `buildKey` call.
- `cache/option_test.go` — renames for old tests + new test suite for the constructor option.
- `cache/redis_test.go` — mock `Del` now records the key.
- `README.md` — doc in the Caching section.